### PR TITLE
refactor: clean Temporal dead code, add logging across core modules

### DIFF
--- a/include/fabric/core/Temporal.hh
+++ b/include/fabric/core/Temporal.hh
@@ -14,8 +14,6 @@
 
 namespace fabric {
 
-class Entity;  // Forward declaration for Entity
-
 /**
  * @brief TimeState captures the state of a timeline at a specific moment
  * 
@@ -98,26 +96,16 @@ public:
     
     /** Set the time scale of this region */
     void setTimeScale(double scale);
-    
-    /** Add an entity to this time region */
-    void addEntity(Entity* entity);
-    
-    /** Remove an entity from this time region */
-    void removeEntity(Entity* entity);
-    
-    /** Get a list of entities in this region */
-    const std::vector<Entity*>& getEntities() const;
-    
-    /** Create a snapshot of all entities in this region */
+
+    /** Create a snapshot capturing this region's local time */
     TimeState createSnapshot() const;
-    
-    /** Restore a snapshot to all entities in this region */
+
+    /** Restore local time from a snapshot */
     void restoreSnapshot(const TimeState& state);
-    
+
 private:
     double timeScale_;
     double localTime_;
-    std::vector<Entity*> entities_;
 };
 
 /**

--- a/src/core/Async.cc
+++ b/src/core/Async.cc
@@ -1,4 +1,5 @@
 #include "fabric/core/Async.hh"
+#include "fabric/core/Log.hh"
 
 #include <optional>
 
@@ -13,9 +14,11 @@ asio::io_context& context() {
 
 void init() {
   work_guard.emplace(asio::make_work_guard(io_ctx));
+  FABRIC_LOG_INFO("Async: subsystem initialized");
 }
 
 void shutdown() {
+  FABRIC_LOG_INFO("Async: subsystem shutting down");
   work_guard.reset();
   io_ctx.run();
 }

--- a/src/core/Lifecycle.cc
+++ b/src/core/Lifecycle.cc
@@ -1,4 +1,5 @@
 #include "fabric/core/Lifecycle.hh"
+#include "fabric/core/Log.hh"
 
 #include <set>
 
@@ -50,7 +51,9 @@ LifecycleManager::LifecycleManager()
 }
 
 void LifecycleManager::setState(LifecycleState state) {
+  auto previous = sm_.getState();
   sm_.setState(state);
+  FABRIC_LOG_DEBUG("Lifecycle: transition {} -> {}", lifecycleStateToString(previous), lifecycleStateToString(state));
 }
 
 LifecycleState LifecycleManager::getState() const {

--- a/src/core/Resource.cc
+++ b/src/core/Resource.cc
@@ -1,4 +1,5 @@
 #include "fabric/core/Resource.hh"
+#include "fabric/core/Log.hh"
 
 namespace fabric {
 
@@ -15,8 +16,10 @@ std::shared_ptr<Resource> ResourceFactory::create(const std::string& typeId, con
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = factories_.find(typeId);
     if (it == factories_.end()) {
+        FABRIC_LOG_ERROR("ResourceFactory: unknown type '{}' for resource '{}'", typeId, id);
         return nullptr;
     }
+    FABRIC_LOG_DEBUG("ResourceFactory: created resource '{}' of type '{}'", id, typeId);
     return it->second(id);
 }
 

--- a/src/core/Spatial.cc
+++ b/src/core/Spatial.cc
@@ -1,4 +1,5 @@
 #include "fabric/core/Spatial.hh"
+#include "fabric/core/Log.hh"
 #include <cmath>
 #include <algorithm>
 
@@ -21,13 +22,15 @@ void SceneNode::update(float deltaTime) {
 
 SceneNode* SceneNode::addChild(std::unique_ptr<SceneNode> child) {
     if (child->parent_) {
-        // If the child already has a parent, detach it first
+        FABRIC_LOG_DEBUG("SceneGraph: reparenting '{}' from '{}' to '{}'",
+                         child->getName(), child->parent_->getName(), name_);
         child->parent_->detachChild(child.get());
     }
-    
+
     SceneNode* childPtr = child.get();
     child->parent_ = this;
     children_.push_back(std::move(child));
+    FABRIC_LOG_DEBUG("SceneGraph: added child '{}' to '{}'", childPtr->getName(), name_);
     return childPtr;
 }
 
@@ -39,6 +42,7 @@ SceneNode* SceneNode::createChild(const std::string& name) {
 std::unique_ptr<SceneNode> SceneNode::detachChild(SceneNode* child) {
     for (auto it = children_.begin(); it != children_.end(); ++it) {
         if (it->get() == child) {
+            FABRIC_LOG_DEBUG("SceneGraph: detached '{}' from '{}'", child->getName(), name_);
             std::unique_ptr<SceneNode> result = std::move(*it);
             children_.erase(it);
             result->parent_ = nullptr;

--- a/src/utils/ErrorHandling.cc
+++ b/src/utils/ErrorHandling.cc
@@ -1,4 +1,5 @@
 #include "fabric/utils/ErrorHandling.hh"
+#include "fabric/core/Log.hh"
 
 namespace fabric {
 
@@ -7,7 +8,10 @@ FabricException::FabricException(const std::string &message)
 
 const char *FabricException::what() const noexcept { return message.c_str(); }
 
-void throwError(const std::string &message) { throw FabricException(message); }
+void throwError(const std::string &message) {
+  FABRIC_LOG_ERROR("FabricException: {}", message);
+  throw FabricException(message);
+}
 
 std::string_view errorCodeToString(ErrorCode code) {
   switch (code) {

--- a/tests/unit/core/TemporalTest.cc
+++ b/tests/unit/core/TemporalTest.cc
@@ -50,32 +50,17 @@ private:
     int updateCount_;
 };
 
-// Mock entity for testing
-class MockEntity {
-public:
-    MockEntity() : value_(0.0) {}
-    
-    double getValue() const { return value_; }
-    void setValue(double value) { value_ = value; }
-    
-private:
-    double value_;
-};
-
 class TemporalTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        // Reset the singleton for each test
         Timeline::reset();
     }
-    
+
     void TearDown() override {
-        // Clean up the singleton after each test
         Timeline::reset();
     }
-    
+
     double testValue = 0.0;
-    MockEntity mockEntity;
 };
 
 TEST_F(TemporalTest, TimeStateBasics) {
@@ -185,40 +170,18 @@ TEST_F(TemporalTest, TimeRegionBasics) {
     // to verify the time scale is applied correctly
 }
 
-TEST_F(TemporalTest, TimeRegionEntityManagement) {
-    TimeRegion region;
-    
-    // Add entities
-    Entity* entity1 = reinterpret_cast<Entity*>(&mockEntity); // Cast for testing
-    region.addEntity(entity1);
-    
-    // Check entities
-    EXPECT_EQ(region.getEntities().size(), 1);
-    EXPECT_EQ(region.getEntities()[0], entity1);
-    
-    // Add same entity again (should not duplicate)
-    region.addEntity(entity1);
-    EXPECT_EQ(region.getEntities().size(), 1);
-    
-    // Remove entity
-    region.removeEntity(entity1);
-    EXPECT_TRUE(region.getEntities().empty());
-}
-
 TEST_F(TemporalTest, TimeRegionSnapshot) {
     TimeRegion region;
-    
-    // Create a time state from the region
+
     TimeState state = region.createSnapshot();
-    
-    // Without any entities, this is mostly a placeholder test
-    EXPECT_EQ(state.getTimestamp(), 0.0); // Initial local time
-    
-    // Test restoring from a snapshot
+    EXPECT_EQ(state.getTimestamp(), 0.0);
+
     TimeState newState(10.0);
     region.restoreSnapshot(newState);
-    
-    // Again, without entities, this is mostly a placeholder
+
+    // After restore, local time should match the snapshot
+    TimeState restored = region.createSnapshot();
+    EXPECT_DOUBLE_EQ(restored.getTimestamp(), 10.0);
 }
 
 TEST_F(TemporalTest, TimelineBasics) {


### PR DESCRIPTION
## Summary

- Remove Temporal dead code: Entity forward decl, 3 unused methods, dead region-merge loop, fix restoreSnapshot
- Fix 6 silent catch blocks in ResourceHub.cc; errors now surface via FABRIC_LOG_ERROR
- Add 15 log calls across Async, Lifecycle, Resource, Spatial, ErrorHandling
- throwError() now logs before throwing
- Remove 3 dead tests; 238/238 tests pass

## Test plan

- [x] `cmake --build --preset dev-debug` compiles clean
- [x] 238/238 unit tests pass
- [x] Net -63 lines (67 insertions, 130 deletions)