### PR TITLE
feat: Sprint 5b movement, combat, and camera

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ set(FABRIC_CORE_SOURCE_FILES
     src/core/Rendering.cc
     src/core/Camera.cc
     src/core/InputManager.cc
+    src/core/InputRouter.cc
     src/core/SceneView.cc
     src/core/ECS.cc
     src/core/Simulation.cc
@@ -150,6 +151,14 @@ set(FABRIC_CORE_SOURCE_FILES
     src/core/VoxelRaycast.cc
     src/core/ChunkStreaming.cc
     src/core/ChunkMeshManager.cc
+    src/core/MovementFSM.cc
+    src/core/CharacterController.cc
+    src/core/CameraController.cc
+    src/core/VoxelInteraction.cc
+    src/core/MeleeSystem.cc
+    src/core/FlightController.cc
+    src/core/TransitionController.cc
+    src/core/DashController.cc
 )
 
 # Utils library components

--- a/include/fabric/core/CameraController.hh
+++ b/include/fabric/core/CameraController.hh
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "fabric/core/Camera.hh"
+#include "fabric/core/ChunkedGrid.hh"
+#include "fabric/core/Spatial.hh"
+#include "fabric/core/VoxelRaycast.hh"
+
+namespace fabric {
+
+enum class CameraMode { FirstPerson, ThirdPerson };
+
+struct CameraConfig {
+    float mouseSensitivity = 0.003f;
+    float fovY = 60.0f;
+    float nearPlane = 0.1f;
+    float farPlane = 1000.0f;
+
+    // Third-person
+    float orbitDistance = 8.0f;
+    float orbitMinDistance = 1.5f;
+    float springArmSmoothing = 10.0f;
+
+    // Eye offset from player position (first person)
+    float eyeHeight = 1.6f;
+
+    // Pitch limits (degrees)
+    float pitchMin = -89.0f;
+    float pitchMax = 89.0f;
+    bool unlockPitch = false;
+};
+
+class CameraController {
+  public:
+    CameraController(Camera& camera, const CameraConfig& config = {});
+
+    void setMode(CameraMode mode);
+    CameraMode mode() const;
+
+    void processMouseInput(float deltaX, float deltaY);
+
+    void update(const Vector3<float, Space::World>& targetPos, float dt,
+                const ChunkedGrid<float>* grid = nullptr, float densityThreshold = 0.5f);
+
+    Vector3<float, Space::World> position() const;
+
+    Vector3<float, Space::World> forward() const;
+    Vector3<float, Space::World> right() const;
+    Vector3<float, Space::World> up() const;
+
+    float yaw() const;
+    float pitch() const;
+    void setYaw(float degrees);
+    void setPitch(float degrees);
+
+    void setUnlockPitch(bool unlock);
+
+    CameraConfig& config();
+
+  private:
+    Quaternion<float> buildRotation() const;
+    void clampPitch();
+    void wrapYaw();
+
+    Camera& camera_;
+    CameraConfig config_;
+    CameraMode mode_ = CameraMode::FirstPerson;
+
+    float yaw_ = 0.0f;
+    float pitch_ = 0.0f;
+    float actualDistance_ = 0.0f;
+
+    Vector3<float, Space::World> cachedPosition_;
+};
+
+} // namespace fabric

--- a/include/fabric/core/CharacterController.hh
+++ b/include/fabric/core/CharacterController.hh
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "fabric/core/ChunkedGrid.hh"
+#include "fabric/core/Rendering.hh"
+#include "fabric/core/Spatial.hh"
+#include <cmath>
+
+namespace fabric {
+
+class CharacterController {
+  public:
+    struct CollisionResult {
+        bool hitX = false;
+        bool hitY = false;
+        bool hitZ = false;
+        bool onGround = false;
+        Vec3f resolvedPosition;
+    };
+
+    CharacterController(float width, float height, float depth);
+
+    CollisionResult move(const Vec3f& currentPos, const Vec3f& displacement,
+                         const ChunkedGrid<float>& grid, float densityThreshold = 0.5f);
+
+    bool checkOnGround(const Vec3f& pos, const ChunkedGrid<float>& grid,
+                       float densityThreshold = 0.5f) const;
+
+    AABB getAABB(const Vec3f& pos) const;
+
+    float stepHeight() const;
+    void setStepHeight(float h);
+
+  private:
+    float width_;
+    float height_;
+    float depth_;
+    float stepHeight_ = 1.0f;
+
+    static constexpr float kGroundEpsilon = 0.01f;
+
+    bool isSolid(int vx, int vy, int vz, const ChunkedGrid<float>& grid,
+                 float threshold) const;
+
+    bool aabbOverlapsSolid(const AABB& box, const ChunkedGrid<float>& grid,
+                           float threshold) const;
+
+    // TODO(human): Implement the step-up resolution strategy
+    float tryStepUp(const Vec3f& pos, float dx, float dz,
+                    const ChunkedGrid<float>& grid, float threshold) const;
+};
+
+} // namespace fabric

--- a/include/fabric/core/CharacterTypes.hh
+++ b/include/fabric/core/CharacterTypes.hh
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstdint>
+
+namespace fabric {
+
+enum class CharacterState : uint8_t {
+    Grounded,
+    Falling,
+    Jumping,
+    Climbing,
+    Swimming,
+    WallRunning,
+    Hanging,
+    Flying,
+    Sliding,
+    Ragdoll,
+    Dashing,
+    Boosting
+};
+
+// ECS components (POD structs for Flecs)
+
+struct Velocity {
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+struct CharacterStateComponent {
+    CharacterState state = CharacterState::Grounded;
+};
+
+struct CharacterConfig {
+    float walkSpeed = 5.0f;
+    float runSpeed = 10.0f;
+    float jumpForce = 8.0f;
+    float gravity = 20.0f;
+    float stepHeight = 1.0f;
+    float slopeLimit = 0.707f; // cos(45 degrees)
+    float flightSpeed = 15.0f;
+    float dashSpeed = 25.0f;
+    float dashDuration = 0.25f;
+    float dashCooldown = 1.5f;
+    float boostSpeed = 30.0f;
+    float boostCooldown = 2.0f;
+};
+
+struct DashState {
+    float cooldownRemaining = 0.0f;
+    float durationRemaining = 0.0f;
+    bool active = false;
+};
+
+} // namespace fabric

--- a/include/fabric/core/DashController.hh
+++ b/include/fabric/core/DashController.hh
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "fabric/core/CharacterTypes.hh"
+#include "fabric/core/Rendering.hh"
+
+namespace fabric {
+
+class DashController {
+  public:
+    struct DashResult {
+        Vec3f displacement;
+        bool active = false;
+        bool justFinished = false;
+    };
+
+    // Start a dash (ground) or boost (air). Returns false if on cooldown.
+    bool startDash(DashState& state, const CharacterConfig& config, bool isAirborne);
+
+    // Tick active dash, return displacement for this frame
+    DashResult update(DashState& state, const CharacterConfig& config,
+                      const Vec3f& dashDirection, float dt, bool isAirborne);
+
+    // Tick cooldown (call every frame regardless of dash state)
+    void updateCooldown(DashState& state, float dt);
+};
+
+} // namespace fabric

--- a/include/fabric/core/FlightController.hh
+++ b/include/fabric/core/FlightController.hh
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "fabric/core/ChunkedGrid.hh"
+#include "fabric/core/Rendering.hh"
+#include "fabric/core/Spatial.hh"
+
+namespace fabric {
+
+class FlightController {
+  public:
+    struct FlightResult {
+        Vec3f resolvedPosition;
+        bool hitX = false;
+        bool hitY = false;
+        bool hitZ = false;
+    };
+
+    FlightController(float width, float height, float depth);
+
+    // 6DOF collision resolution: displacement in world space, no gravity, no step-up
+    FlightResult move(const Vec3f& currentPos, const Vec3f& displacement,
+                      const ChunkedGrid<float>& grid,
+                      float densityThreshold = 0.5f);
+
+    // Drag utility: velocity *= (1 - drag * dt), clamps near-zero
+    static Vec3f applyDrag(const Vec3f& velocity, float dragCoefficient, float dt);
+
+    AABB getAABB(const Vec3f& pos) const;
+
+  private:
+    float width_;
+    float height_;
+    float depth_;
+
+    static constexpr float kEpsilon = 0.01f;
+    static constexpr float kDragFloor = 0.01f;
+
+    bool isSolid(int vx, int vy, int vz, const ChunkedGrid<float>& grid,
+                 float threshold) const;
+
+    bool aabbOverlapsSolid(const AABB& box, const ChunkedGrid<float>& grid,
+                           float threshold) const;
+};
+
+} // namespace fabric

--- a/include/fabric/core/InputRouter.hh
+++ b/include/fabric/core/InputRouter.hh
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "fabric/core/InputManager.hh"
+#include <RmlUi/Core/Input.h>
+#include <SDL3/SDL.h>
+
+namespace Rml {
+class Context;
+class Element;
+} // namespace Rml
+
+namespace fabric {
+
+enum class InputMode { GameOnly, UIOnly, GameAndUI };
+
+class InputRouter {
+  public:
+    explicit InputRouter(InputManager& inputMgr);
+
+    void setMode(InputMode mode);
+    InputMode mode() const;
+
+    // Route an SDL event. Returns true if consumed.
+    // When Rml::Context is null, UI forwarding is skipped.
+    bool routeEvent(const SDL_Event& event, Rml::Context* rmlContext);
+
+    // Call at frame start (resets per-frame state)
+    void beginFrame();
+
+    // Toggle between GameOnly and UIOnly
+    void toggleUIMode();
+
+    // SDL-to-RmlUI key mapping (public for testing)
+    static Rml::Input::KeyIdentifier sdlKeyToRmlKey(SDL_Keycode key);
+    static int sdlModToRmlMod(SDL_Keymod mod);
+
+  private:
+    InputManager& inputMgr_;
+    InputMode mode_ = InputMode::GameOnly;
+
+    bool forwardToRmlUI(const SDL_Event& event, Rml::Context* ctx);
+    bool forwardToGame(const SDL_Event& event);
+
+    static int sdlMouseButtonToRml(Uint8 button);
+    static bool isBodyElement(Rml::Element* element);
+};
+
+} // namespace fabric

--- a/include/fabric/core/MeleeSystem.hh
+++ b/include/fabric/core/MeleeSystem.hh
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "fabric/core/Event.hh"
+#include "fabric/core/Rendering.hh"
+#include "fabric/core/Spatial.hh"
+
+#include <cstddef>
+#include <vector>
+
+namespace fabric {
+
+struct MeleeConfig {
+    float reach = 3.0f;
+    float width = 2.0f;
+    float height = 2.0f;
+    float cooldown = 0.5f;
+    float damage = 10.0f;
+    float knockback = 5.0f;
+};
+
+struct MeleeAttack {
+    AABB hitbox;
+    float damage;
+    float knockback;
+    Vector3<float, Space::World> direction;
+};
+
+class MeleeSystem {
+  public:
+    MeleeSystem(EventDispatcher& dispatcher);
+
+    // Generate attack hitbox from player position + facing direction
+    // Aligns hitbox to nearest world axis (Sprint 5b simplification)
+    MeleeAttack createAttack(
+        const Vector3<float, Space::World>& playerPos,
+        const Vector3<float, Space::World>& facingDir,
+        const MeleeConfig& config);
+
+    // Check if attack hitbox overlaps any target AABBs. Returns indices of hit targets.
+    std::vector<size_t> checkHits(
+        const MeleeAttack& attack,
+        const std::vector<AABB>& targetBounds);
+
+    bool canAttack(float cooldownRemaining) const;
+    float updateCooldown(float remaining, float dt) const;
+
+    void emitDamageEvent(
+        const Vector3<float, Space::World>& targetPos,
+        float damage,
+        const Vector3<float, Space::World>& knockbackDir);
+
+  private:
+    EventDispatcher& dispatcher_;
+};
+
+} // namespace fabric

--- a/include/fabric/core/MovementFSM.hh
+++ b/include/fabric/core/MovementFSM.hh
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "fabric/core/CharacterTypes.hh"
+#include "fabric/core/StateMachine.hh"
+#include <memory>
+#include <string>
+
+namespace fabric {
+
+class MovementFSM {
+  public:
+    MovementFSM();
+
+    bool tryTransition(CharacterState target);
+    CharacterState currentState() const;
+
+    bool isGrounded() const;
+    bool isAirborne() const;
+    bool isFlying() const;
+    bool canDash() const;
+
+    static std::string stateToString(CharacterState state);
+
+  private:
+    std::unique_ptr<StateMachine<CharacterState>> sm_;
+};
+
+} // namespace fabric

--- a/include/fabric/core/TransitionController.hh
+++ b/include/fabric/core/TransitionController.hh
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "fabric/core/CharacterTypes.hh"
+#include "fabric/core/ChunkedGrid.hh"
+#include "fabric/core/Rendering.hh"
+
+namespace fabric {
+
+class TransitionController {
+  public:
+    struct TransitionResult {
+        Vec3f velocity;
+        CharacterState newState;
+    };
+
+    // Grounded/Jumping -> Flying: preserve horizontal momentum, add upward impulse
+    TransitionResult enterFlight(
+        const Vec3f& currentVelocity,
+        float upwardImpulse = 5.0f,
+        float momentumScale = 0.8f);
+
+    // Flying -> Falling/Grounded: check ground proximity via downward scan
+    TransitionResult exitFlight(
+        const Vec3f& currentVelocity,
+        const Vec3f& position,
+        const ChunkedGrid<float>& grid,
+        float groundCheckDistance = 2.0f,
+        float densityThreshold = 0.5f);
+
+  private:
+    bool checkGroundBelow(const Vec3f& position,
+                          const ChunkedGrid<float>& grid,
+                          float distance,
+                          float densityThreshold) const;
+};
+
+} // namespace fabric

--- a/include/fabric/core/VoxelInteraction.hh
+++ b/include/fabric/core/VoxelInteraction.hh
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "fabric/core/Event.hh"
+#include "fabric/core/FieldLayer.hh"
+#include "fabric/core/Rendering.hh"
+#include "fabric/core/VoxelRaycast.hh"
+
+namespace fabric {
+
+struct InteractionResult {
+    bool success;
+    int x, y, z;
+    int cx, cy, cz;
+};
+
+class VoxelInteraction {
+  public:
+    VoxelInteraction(DensityField& density, EssenceField& essence, EventDispatcher& dispatcher);
+
+    // Place voxel adjacent to hit face
+    InteractionResult createMatter(
+        const VoxelHit& hit,
+        float density = 1.0f,
+        const Vector4<float, Space::World>& essenceColor = {0.5f, 0.5f, 0.5f, 1.0f});
+
+    // Remove voxel at hit position
+    InteractionResult destroyMatter(const VoxelHit& hit);
+
+    // Raycast + create in one call
+    InteractionResult createMatterAt(
+        const ChunkedGrid<float>& grid,
+        float ox, float oy, float oz,
+        float dx, float dy, float dz,
+        float density = 1.0f,
+        const Vector4<float, Space::World>& essenceColor = {0.5f, 0.5f, 0.5f, 1.0f},
+        float maxDistance = 10.0f);
+
+    // Raycast + destroy in one call
+    InteractionResult destroyMatterAt(
+        const ChunkedGrid<float>& grid,
+        float ox, float oy, float oz,
+        float dx, float dy, float dz,
+        float maxDistance = 10.0f);
+
+    // Check if placing at position would overlap an AABB (player push-out check)
+    static bool wouldOverlap(int vx, int vy, int vz, const AABB& playerBounds);
+
+  private:
+    DensityField& density_;
+    EssenceField& essence_;
+    EventDispatcher& dispatcher_;
+};
+
+} // namespace fabric

--- a/src/core/CameraController.cc
+++ b/src/core/CameraController.cc
@@ -1,0 +1,147 @@
+#include "fabric/core/CameraController.hh"
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+namespace fabric {
+
+namespace {
+
+constexpr float kDegToRad = std::numbers::pi_v<float> / 180.0f;
+constexpr float kSpringArmClipOffset = 0.2f;
+
+float wrapAngle(float degrees) {
+    degrees = std::fmod(degrees, 360.0f);
+    if (degrees < 0.0f)
+        degrees += 360.0f;
+    return degrees;
+}
+
+} // namespace
+
+CameraController::CameraController(Camera& camera, const CameraConfig& config)
+    : camera_(camera), config_(config), actualDistance_(config.orbitDistance) {}
+
+void CameraController::setMode(CameraMode mode) {
+    mode_ = mode;
+    if (mode == CameraMode::ThirdPerson)
+        actualDistance_ = config_.orbitDistance;
+}
+
+CameraMode CameraController::mode() const {
+    return mode_;
+}
+
+void CameraController::processMouseInput(float deltaX, float deltaY) {
+    yaw_ -= deltaX * config_.mouseSensitivity / kDegToRad;
+    pitch_ -= deltaY * config_.mouseSensitivity / kDegToRad;
+    wrapYaw();
+    clampPitch();
+}
+
+void CameraController::update(const Vector3<float, Space::World>& targetPos, float dt,
+                               const ChunkedGrid<float>* grid, float densityThreshold) {
+    using Vec3 = Vector3<float, Space::World>;
+
+    Vec3 eyePoint = targetPos + Vec3(0.0f, config_.eyeHeight, 0.0f);
+    auto rot = buildRotation();
+    // Left-handed: forward = +Z
+    Vec3 fwd = rot.rotateVector(Vec3(0.0f, 0.0f, 1.0f));
+
+    if (mode_ == CameraMode::FirstPerson) {
+        cachedPosition_ = eyePoint;
+    } else {
+        // Third person: camera behind the player (opposite of forward)
+        float targetDist = config_.orbitDistance;
+
+        if (grid) {
+            // Cast ray from eye point backward (negative forward) to find obstructions
+            Vec3 rayDir = Vec3(0.0f, 0.0f, 0.0f) - fwd; // -forward
+            auto hit = castRay(*grid, eyePoint.x, eyePoint.y, eyePoint.z, rayDir.x, rayDir.y, rayDir.z,
+                               config_.orbitDistance, densityThreshold);
+            if (hit && hit->t < targetDist) {
+                targetDist = std::max(hit->t - kSpringArmClipOffset, config_.orbitMinDistance);
+            }
+        }
+
+        // Smooth distance transition
+        actualDistance_ += (targetDist - actualDistance_) * std::min(config_.springArmSmoothing * dt, 1.0f);
+        actualDistance_ = std::max(actualDistance_, config_.orbitMinDistance);
+
+        cachedPosition_ = eyePoint - fwd * actualDistance_;
+    }
+
+    // Build transform and update the underlying Camera
+    Transform<float> camTransform;
+    camTransform.setPosition(cachedPosition_);
+    camTransform.setRotation(rot);
+    camera_.updateView(camTransform);
+}
+
+Vector3<float, Space::World> CameraController::position() const {
+    return cachedPosition_;
+}
+
+Vector3<float, Space::World> CameraController::forward() const {
+    return buildRotation().rotateVector(Vector3<float, Space::World>(0.0f, 0.0f, 1.0f));
+}
+
+Vector3<float, Space::World> CameraController::right() const {
+    return buildRotation().rotateVector(Vector3<float, Space::World>(1.0f, 0.0f, 0.0f));
+}
+
+Vector3<float, Space::World> CameraController::up() const {
+    return buildRotation().rotateVector(Vector3<float, Space::World>(0.0f, 1.0f, 0.0f));
+}
+
+float CameraController::yaw() const {
+    return yaw_;
+}
+
+float CameraController::pitch() const {
+    return pitch_;
+}
+
+void CameraController::setYaw(float degrees) {
+    yaw_ = degrees;
+    wrapYaw();
+}
+
+void CameraController::setPitch(float degrees) {
+    pitch_ = degrees;
+    clampPitch();
+}
+
+void CameraController::setUnlockPitch(bool unlock) {
+    config_.unlockPitch = unlock;
+}
+
+CameraConfig& CameraController::config() {
+    return config_;
+}
+
+Quaternion<float> CameraController::buildRotation() const {
+    // Yaw around Y axis, then pitch around X axis
+    float yawRad = yaw_ * kDegToRad;
+    float pitchRad = pitch_ * kDegToRad;
+
+    auto yawQuat = Quaternion<float>::fromAxisAngle(Vector3<float, Space::World>(0.0f, 1.0f, 0.0f), yawRad);
+    auto pitchQuat = Quaternion<float>::fromAxisAngle(Vector3<float, Space::World>(1.0f, 0.0f, 0.0f), pitchRad);
+
+    return yawQuat * pitchQuat;
+}
+
+void CameraController::clampPitch() {
+    if (config_.unlockPitch) {
+        pitch_ = wrapAngle(pitch_);
+    } else {
+        pitch_ = std::clamp(pitch_, config_.pitchMin, config_.pitchMax);
+    }
+}
+
+void CameraController::wrapYaw() {
+    yaw_ = wrapAngle(yaw_);
+}
+
+} // namespace fabric

--- a/src/core/CharacterController.cc
+++ b/src/core/CharacterController.cc
@@ -1,0 +1,168 @@
+#include "fabric/core/CharacterController.hh"
+#include "fabric/core/Log.hh"
+#include <algorithm>
+#include <cmath>
+
+namespace fabric {
+
+CharacterController::CharacterController(float width, float height, float depth)
+    : width_(width), height_(height), depth_(depth) {}
+
+AABB CharacterController::getAABB(const Vec3f& pos) const {
+    float hw = width_ * 0.5f;
+    float hd = depth_ * 0.5f;
+    Vec3f minCorner(pos.x - hw, pos.y, pos.z - hd);
+    Vec3f maxCorner(pos.x + hw, pos.y + height_, pos.z + hd);
+    return AABB(minCorner, maxCorner);
+}
+
+bool CharacterController::isSolid(int vx, int vy, int vz, const ChunkedGrid<float>& grid,
+                                   float threshold) const {
+    return grid.get(vx, vy, vz) >= threshold;
+}
+
+bool CharacterController::aabbOverlapsSolid(const AABB& box, const ChunkedGrid<float>& grid,
+                                             float threshold) const {
+    int minVX = static_cast<int>(std::floor(box.min.x));
+    int minVY = static_cast<int>(std::floor(box.min.y));
+    int minVZ = static_cast<int>(std::floor(box.min.z));
+    int maxVX = static_cast<int>(std::floor(box.max.x - kGroundEpsilon));
+    int maxVY = static_cast<int>(std::floor(box.max.y - kGroundEpsilon));
+    int maxVZ = static_cast<int>(std::floor(box.max.z - kGroundEpsilon));
+
+    for (int vy = minVY; vy <= maxVY; ++vy)
+        for (int vz = minVZ; vz <= maxVZ; ++vz)
+            for (int vx = minVX; vx <= maxVX; ++vx)
+                if (isSolid(vx, vy, vz, grid, threshold))
+                    return true;
+    return false;
+}
+
+float CharacterController::tryStepUp(const Vec3f& pos, float dx, float dz,
+                                      const ChunkedGrid<float>& grid, float threshold) const {
+    // TODO(human): Implement the step-up resolution strategy
+    // Try stepping up by increments up to stepHeight_ to clear obstacles.
+    // Return the Y offset needed, or 0 if step-up is not possible.
+    for (float step = 1.0f; step <= stepHeight_; step += 1.0f) {
+        Vec3f stepped(pos.x + dx, pos.y + step, pos.z + dz);
+        AABB box = getAABB(stepped);
+        if (!aabbOverlapsSolid(box, grid, threshold)) {
+            return step;
+        }
+    }
+    return 0.0f;
+}
+
+CharacterController::CollisionResult CharacterController::move(
+    const Vec3f& currentPos, const Vec3f& displacement,
+    const ChunkedGrid<float>& grid, float densityThreshold) {
+
+    CollisionResult result;
+    Vec3f pos = currentPos;
+
+    // Resolve Y axis first (gravity/jump)
+    {
+        Vec3f candidate(pos.x, pos.y + displacement.y, pos.z);
+        AABB box = getAABB(candidate);
+        if (aabbOverlapsSolid(box, grid, densityThreshold)) {
+            result.hitY = true;
+            // Clamp: if moving down, push up to voxel top; if moving up, push down
+            if (displacement.y < 0.0f) {
+                // Find the highest blocking voxel below feet
+                int footVY = static_cast<int>(std::floor(candidate.y));
+                AABB footBox = getAABB(candidate);
+                int minVX = static_cast<int>(std::floor(footBox.min.x));
+                int maxVX = static_cast<int>(std::floor(footBox.max.x - kGroundEpsilon));
+                int minVZ = static_cast<int>(std::floor(footBox.min.z));
+                int maxVZ = static_cast<int>(std::floor(footBox.max.z - kGroundEpsilon));
+                float highestTop = candidate.y;
+                for (int vz = minVZ; vz <= maxVZ; ++vz) {
+                    for (int vx = minVX; vx <= maxVX; ++vx) {
+                        for (int vy = footVY; vy <= static_cast<int>(std::floor(pos.y)); ++vy) {
+                            if (isSolid(vx, vy, vz, grid, densityThreshold)) {
+                                float top = static_cast<float>(vy + 1);
+                                if (top > highestTop) highestTop = top;
+                            }
+                        }
+                    }
+                }
+                pos.y = highestTop;
+            } else {
+                // Moving up, clamp to below the blocking voxel
+                pos.y = pos.y; // Stay put on Y
+            }
+        } else {
+            pos.y = candidate.y;
+        }
+    }
+
+    // Resolve X axis
+    {
+        Vec3f candidate(pos.x + displacement.x, pos.y, pos.z);
+        AABB box = getAABB(candidate);
+        if (aabbOverlapsSolid(box, grid, densityThreshold)) {
+            // Try step-up
+            float stepOffset = tryStepUp(pos, displacement.x, 0.0f, grid, densityThreshold);
+            if (stepOffset > 0.0f) {
+                pos.x += displacement.x;
+                pos.y += stepOffset;
+            } else {
+                result.hitX = true;
+            }
+        } else {
+            pos.x = candidate.x;
+        }
+    }
+
+    // Resolve Z axis
+    {
+        Vec3f candidate(pos.x, pos.y, pos.z + displacement.z);
+        AABB box = getAABB(candidate);
+        if (aabbOverlapsSolid(box, grid, densityThreshold)) {
+            // Try step-up
+            float stepOffset = tryStepUp(pos, 0.0f, displacement.z, grid, densityThreshold);
+            if (stepOffset > 0.0f) {
+                pos.z += displacement.z;
+                pos.y += stepOffset;
+            } else {
+                result.hitZ = true;
+            }
+        } else {
+            pos.z = candidate.z;
+        }
+    }
+
+    result.onGround = checkOnGround(pos, grid, densityThreshold);
+    result.resolvedPosition = pos;
+    return result;
+}
+
+bool CharacterController::checkOnGround(const Vec3f& pos, const ChunkedGrid<float>& grid,
+                                         float densityThreshold) const {
+    // Check voxels directly below feet
+    float checkY = pos.y - kGroundEpsilon;
+    int vy = static_cast<int>(std::floor(checkY));
+
+    float hw = width_ * 0.5f;
+    float hd = depth_ * 0.5f;
+    int minVX = static_cast<int>(std::floor(pos.x - hw));
+    int maxVX = static_cast<int>(std::floor(pos.x + hw - kGroundEpsilon));
+    int minVZ = static_cast<int>(std::floor(pos.z - hd));
+    int maxVZ = static_cast<int>(std::floor(pos.z + hd - kGroundEpsilon));
+
+    for (int vz = minVZ; vz <= maxVZ; ++vz)
+        for (int vx = minVX; vx <= maxVX; ++vx)
+            if (isSolid(vx, vy, vz, grid, densityThreshold))
+                return true;
+    return false;
+}
+
+float CharacterController::stepHeight() const {
+    return stepHeight_;
+}
+
+void CharacterController::setStepHeight(float h) {
+    stepHeight_ = h;
+}
+
+} // namespace fabric

--- a/src/core/DashController.cc
+++ b/src/core/DashController.cc
@@ -1,0 +1,48 @@
+#include "fabric/core/DashController.hh"
+#include <algorithm>
+
+namespace fabric {
+
+bool DashController::startDash(DashState& state, const CharacterConfig& config, bool isAirborne) {
+    if (state.cooldownRemaining > 0.0f) {
+        return false;
+    }
+
+    state.active = true;
+    state.durationRemaining = config.dashDuration;
+    state.cooldownRemaining = isAirborne ? config.boostCooldown : config.dashCooldown;
+    return true;
+}
+
+DashController::DashResult DashController::update(
+    DashState& state, const CharacterConfig& config,
+    const Vec3f& dashDirection, float dt, bool isAirborne) {
+
+    DashResult result;
+
+    if (!state.active) {
+        return result;
+    }
+
+    float speed = isAirborne ? config.boostSpeed : config.dashSpeed;
+    result.displacement = dashDirection * (speed * dt);
+    result.active = true;
+
+    state.durationRemaining -= dt;
+    if (state.durationRemaining <= 0.0f) {
+        state.durationRemaining = 0.0f;
+        state.active = false;
+        result.active = false;
+        result.justFinished = true;
+    }
+
+    return result;
+}
+
+void DashController::updateCooldown(DashState& state, float dt) {
+    if (state.cooldownRemaining > 0.0f) {
+        state.cooldownRemaining = std::max(0.0f, state.cooldownRemaining - dt);
+    }
+}
+
+} // namespace fabric

--- a/src/core/FlightController.cc
+++ b/src/core/FlightController.cc
@@ -1,0 +1,97 @@
+#include "fabric/core/FlightController.hh"
+#include <algorithm>
+#include <cmath>
+
+namespace fabric {
+
+FlightController::FlightController(float width, float height, float depth)
+    : width_(width), height_(height), depth_(depth) {}
+
+AABB FlightController::getAABB(const Vec3f& pos) const {
+    float hw = width_ * 0.5f;
+    float hd = depth_ * 0.5f;
+    Vec3f minCorner(pos.x - hw, pos.y, pos.z - hd);
+    Vec3f maxCorner(pos.x + hw, pos.y + height_, pos.z + hd);
+    return AABB(minCorner, maxCorner);
+}
+
+bool FlightController::isSolid(int vx, int vy, int vz, const ChunkedGrid<float>& grid,
+                                float threshold) const {
+    return grid.get(vx, vy, vz) >= threshold;
+}
+
+bool FlightController::aabbOverlapsSolid(const AABB& box, const ChunkedGrid<float>& grid,
+                                          float threshold) const {
+    int minVX = static_cast<int>(std::floor(box.min.x));
+    int minVY = static_cast<int>(std::floor(box.min.y));
+    int minVZ = static_cast<int>(std::floor(box.min.z));
+    int maxVX = static_cast<int>(std::floor(box.max.x - kEpsilon));
+    int maxVY = static_cast<int>(std::floor(box.max.y - kEpsilon));
+    int maxVZ = static_cast<int>(std::floor(box.max.z - kEpsilon));
+
+    for (int vy = minVY; vy <= maxVY; ++vy)
+        for (int vz = minVZ; vz <= maxVZ; ++vz)
+            for (int vx = minVX; vx <= maxVX; ++vx)
+                if (isSolid(vx, vy, vz, grid, threshold))
+                    return true;
+    return false;
+}
+
+Vec3f FlightController::applyDrag(const Vec3f& velocity, float dragCoefficient, float dt) {
+    float factor = std::max(0.0f, 1.0f - dragCoefficient * dt);
+    Vec3f result = velocity * factor;
+
+    // Clamp near-zero to zero
+    float speed = std::sqrt(result.x * result.x + result.y * result.y + result.z * result.z);
+    if (speed < kDragFloor) {
+        return Vec3f(0.0f, 0.0f, 0.0f);
+    }
+    return result;
+}
+
+FlightController::FlightResult FlightController::move(
+    const Vec3f& currentPos, const Vec3f& displacement,
+    const ChunkedGrid<float>& grid, float densityThreshold) {
+
+    FlightResult result;
+    Vec3f pos = currentPos;
+
+    // All 3 axes resolved with equal priority (6DOF, no gravity bias)
+    // X axis
+    {
+        Vec3f candidate(pos.x + displacement.x, pos.y, pos.z);
+        AABB box = getAABB(candidate);
+        if (aabbOverlapsSolid(box, grid, densityThreshold)) {
+            result.hitX = true;
+        } else {
+            pos.x = candidate.x;
+        }
+    }
+
+    // Y axis
+    {
+        Vec3f candidate(pos.x, pos.y + displacement.y, pos.z);
+        AABB box = getAABB(candidate);
+        if (aabbOverlapsSolid(box, grid, densityThreshold)) {
+            result.hitY = true;
+        } else {
+            pos.y = candidate.y;
+        }
+    }
+
+    // Z axis
+    {
+        Vec3f candidate(pos.x, pos.y, pos.z + displacement.z);
+        AABB box = getAABB(candidate);
+        if (aabbOverlapsSolid(box, grid, densityThreshold)) {
+            result.hitZ = true;
+        } else {
+            pos.z = candidate.z;
+        }
+    }
+
+    result.resolvedPosition = pos;
+    return result;
+}
+
+} // namespace fabric

--- a/src/core/InputRouter.cc
+++ b/src/core/InputRouter.cc
@@ -1,0 +1,271 @@
+#include "fabric/core/InputRouter.hh"
+#include "fabric/core/Log.hh"
+
+#include <RmlUi/Core/Context.h>
+#include <RmlUi/Core/Element.h>
+
+#include <unordered_map>
+
+namespace fabric {
+
+InputRouter::InputRouter(InputManager& inputMgr) : inputMgr_(inputMgr) {}
+
+void InputRouter::setMode(InputMode mode) {
+    if (mode_ != mode) {
+        FABRIC_LOG_DEBUG("InputMode: {} -> {}",
+                         static_cast<int>(mode_), static_cast<int>(mode));
+        mode_ = mode;
+    }
+}
+
+InputMode InputRouter::mode() const {
+    return mode_;
+}
+
+bool InputRouter::routeEvent(const SDL_Event& event, Rml::Context* rmlContext) {
+    // Escape toggles GameOnly <-> UIOnly before any other routing
+    if (event.type == SDL_EVENT_KEY_DOWN && !event.key.repeat &&
+        event.key.key == SDLK_ESCAPE) {
+        toggleUIMode();
+        return true;
+    }
+
+    switch (mode_) {
+        case InputMode::GameOnly:
+            return forwardToGame(event);
+
+        case InputMode::UIOnly:
+            if (rmlContext) {
+                return forwardToRmlUI(event, rmlContext);
+            }
+            return false;
+
+        case InputMode::GameAndUI: {
+            if (!rmlContext) {
+                return forwardToGame(event);
+            }
+
+            // Text input always goes to RmlUI in this mode
+            if (event.type == SDL_EVENT_TEXT_INPUT) {
+                return forwardToRmlUI(event, rmlContext);
+            }
+
+            // Mouse events: UI first, game as fallback
+            if (event.type == SDL_EVENT_MOUSE_MOTION ||
+                event.type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
+                event.type == SDL_EVENT_MOUSE_BUTTON_UP ||
+                event.type == SDL_EVENT_MOUSE_WHEEL) {
+
+                // Forward to RmlUI first
+                forwardToRmlUI(event, rmlContext);
+
+                // Check if RmlUI has a hovered element beyond the body
+                Rml::Element* hover = rmlContext->GetHoverElement();
+                if (hover && !isBodyElement(hover)) {
+                    return true; // consumed by UI
+                }
+
+                // UI didn't claim it, forward to game
+                return forwardToGame(event);
+            }
+
+            // Keyboard: check if RmlUI has focus on a text input
+            if (event.type == SDL_EVENT_KEY_DOWN || event.type == SDL_EVENT_KEY_UP) {
+                Rml::Element* focus = rmlContext->GetFocusElement();
+                if (focus && !isBodyElement(focus)) {
+                    return forwardToRmlUI(event, rmlContext);
+                }
+                return forwardToGame(event);
+            }
+
+            return forwardToGame(event);
+        }
+    }
+
+    return false;
+}
+
+void InputRouter::beginFrame() {
+    inputMgr_.beginFrame();
+}
+
+void InputRouter::toggleUIMode() {
+    if (mode_ == InputMode::GameOnly) {
+        setMode(InputMode::UIOnly);
+    } else if (mode_ == InputMode::UIOnly) {
+        setMode(InputMode::GameOnly);
+    }
+    // GameAndUI stays as-is on toggle
+}
+
+bool InputRouter::forwardToRmlUI(const SDL_Event& event, Rml::Context* ctx) {
+    switch (event.type) {
+        case SDL_EVENT_KEY_DOWN: {
+            auto rmlKey = sdlKeyToRmlKey(event.key.key);
+            int rmlMod = sdlModToRmlMod(event.key.mod);
+            return ctx->ProcessKeyDown(rmlKey, rmlMod);
+        }
+
+        case SDL_EVENT_KEY_UP: {
+            auto rmlKey = sdlKeyToRmlKey(event.key.key);
+            int rmlMod = sdlModToRmlMod(event.key.mod);
+            return ctx->ProcessKeyUp(rmlKey, rmlMod);
+        }
+
+        case SDL_EVENT_MOUSE_MOTION: {
+            int rmlMod = sdlModToRmlMod(SDL_GetModState());
+            return ctx->ProcessMouseMove(
+                static_cast<int>(event.motion.x),
+                static_cast<int>(event.motion.y),
+                rmlMod);
+        }
+
+        case SDL_EVENT_MOUSE_BUTTON_DOWN: {
+            int rmlMod = sdlModToRmlMod(SDL_GetModState());
+            int rmlButton = sdlMouseButtonToRml(event.button.button);
+            return ctx->ProcessMouseButtonDown(rmlButton, rmlMod);
+        }
+
+        case SDL_EVENT_MOUSE_BUTTON_UP: {
+            int rmlMod = sdlModToRmlMod(SDL_GetModState());
+            int rmlButton = sdlMouseButtonToRml(event.button.button);
+            return ctx->ProcessMouseButtonUp(rmlButton, rmlMod);
+        }
+
+        case SDL_EVENT_MOUSE_WHEEL: {
+            int rmlMod = sdlModToRmlMod(SDL_GetModState());
+            return ctx->ProcessMouseWheel(event.wheel.y, rmlMod);
+        }
+
+        case SDL_EVENT_TEXT_INPUT: {
+            if (event.text.text) {
+                return ctx->ProcessTextInput(Rml::String(event.text.text));
+            }
+            return false;
+        }
+
+        default:
+            return false;
+    }
+}
+
+bool InputRouter::forwardToGame(const SDL_Event& event) {
+    return inputMgr_.processEvent(event);
+}
+
+int InputRouter::sdlMouseButtonToRml(Uint8 button) {
+    // RmlUI convention: left=0, right=1, middle=2
+    switch (button) {
+        case SDL_BUTTON_LEFT:   return 0;
+        case SDL_BUTTON_RIGHT:  return 1;
+        case SDL_BUTTON_MIDDLE: return 2;
+        case SDL_BUTTON_X1:     return 3;
+        case SDL_BUTTON_X2:     return 4;
+        default:                return 0;
+    }
+}
+
+bool InputRouter::isBodyElement(Rml::Element* element) {
+    if (!element) return true;
+    return element->GetTagName() == "body";
+}
+
+// SDL keycode -> RmlUI KeyIdentifier mapping
+Rml::Input::KeyIdentifier InputRouter::sdlKeyToRmlKey(SDL_Keycode key) {
+    // A-Z: SDL keycodes for lowercase letters are 0x61-0x7a
+    if (key >= SDLK_A && key <= SDLK_Z) {
+        return static_cast<Rml::Input::KeyIdentifier>(
+            Rml::Input::KI_A + (key - SDLK_A));
+    }
+
+    // 0-9: SDL keycodes are 0x30-0x39
+    if (key >= SDLK_0 && key <= SDLK_9) {
+        return static_cast<Rml::Input::KeyIdentifier>(
+            Rml::Input::KI_0 + (key - SDLK_0));
+    }
+
+    // F1-F12
+    if (key >= SDLK_F1 && key <= SDLK_F12) {
+        return static_cast<Rml::Input::KeyIdentifier>(
+            Rml::Input::KI_F1 + (key - SDLK_F1));
+    }
+
+    // Numpad 1-9 (SDL orders KP_1..KP_9, then KP_0)
+    if (key >= SDLK_KP_1 && key <= SDLK_KP_9) {
+        return static_cast<Rml::Input::KeyIdentifier>(
+            Rml::Input::KI_NUMPAD1 + (key - SDLK_KP_1));
+    }
+    if (key == SDLK_KP_0) {
+        return Rml::Input::KI_NUMPAD0;
+    }
+
+    // Individual keys
+    static const std::unordered_map<SDL_Keycode, Rml::Input::KeyIdentifier> keyMap = {
+        {SDLK_SPACE,      Rml::Input::KI_SPACE},
+        {SDLK_RETURN,     Rml::Input::KI_RETURN},
+        {SDLK_KP_ENTER,   Rml::Input::KI_NUMPADENTER},
+        {SDLK_ESCAPE,     Rml::Input::KI_ESCAPE},
+        {SDLK_BACKSPACE,  Rml::Input::KI_BACK},
+        {SDLK_TAB,        Rml::Input::KI_TAB},
+        {SDLK_DELETE,     Rml::Input::KI_DELETE},
+        {SDLK_INSERT,     Rml::Input::KI_INSERT},
+        {SDLK_HOME,       Rml::Input::KI_HOME},
+        {SDLK_END,        Rml::Input::KI_END},
+        {SDLK_PAGEUP,     Rml::Input::KI_PRIOR},
+        {SDLK_PAGEDOWN,   Rml::Input::KI_NEXT},
+        {SDLK_LEFT,       Rml::Input::KI_LEFT},
+        {SDLK_RIGHT,      Rml::Input::KI_RIGHT},
+        {SDLK_UP,         Rml::Input::KI_UP},
+        {SDLK_DOWN,       Rml::Input::KI_DOWN},
+        {SDLK_LSHIFT,     Rml::Input::KI_LSHIFT},
+        {SDLK_RSHIFT,     Rml::Input::KI_RSHIFT},
+        {SDLK_LCTRL,      Rml::Input::KI_LCONTROL},
+        {SDLK_RCTRL,      Rml::Input::KI_RCONTROL},
+        {SDLK_LALT,       Rml::Input::KI_LMENU},
+        {SDLK_RALT,       Rml::Input::KI_RMENU},
+        {SDLK_LGUI,       Rml::Input::KI_LMETA},
+        {SDLK_RGUI,       Rml::Input::KI_RMETA},
+        {SDLK_CAPSLOCK,   Rml::Input::KI_CAPITAL},
+        {SDLK_NUMLOCKCLEAR, Rml::Input::KI_NUMLOCK},
+        {SDLK_SCROLLLOCK,   Rml::Input::KI_SCROLL},
+        {SDLK_PAUSE,      Rml::Input::KI_PAUSE},
+        {SDLK_PRINTSCREEN, Rml::Input::KI_SNAPSHOT},
+        {SDLK_SEMICOLON,  Rml::Input::KI_OEM_1},
+        {SDLK_EQUALS,     Rml::Input::KI_OEM_PLUS},
+        {SDLK_COMMA,      Rml::Input::KI_OEM_COMMA},
+        {SDLK_MINUS,      Rml::Input::KI_OEM_MINUS},
+        {SDLK_PERIOD,     Rml::Input::KI_OEM_PERIOD},
+        {SDLK_SLASH,      Rml::Input::KI_OEM_2},
+        {SDLK_GRAVE,      Rml::Input::KI_OEM_3},
+        {SDLK_LEFTBRACKET,  Rml::Input::KI_OEM_4},
+        {SDLK_BACKSLASH,    Rml::Input::KI_OEM_5},
+        {SDLK_RIGHTBRACKET, Rml::Input::KI_OEM_6},
+        {SDLK_APOSTROPHE,   Rml::Input::KI_OEM_7},
+        {SDLK_KP_MULTIPLY,  Rml::Input::KI_MULTIPLY},
+        {SDLK_KP_PLUS,      Rml::Input::KI_ADD},
+        {SDLK_KP_MINUS,     Rml::Input::KI_SUBTRACT},
+        {SDLK_KP_PERIOD,    Rml::Input::KI_DECIMAL},
+        {SDLK_KP_DIVIDE,    Rml::Input::KI_DIVIDE},
+    };
+
+    auto it = keyMap.find(key);
+    if (it != keyMap.end()) {
+        return it->second;
+    }
+
+    return Rml::Input::KI_UNKNOWN;
+}
+
+int InputRouter::sdlModToRmlMod(SDL_Keymod mod) {
+    int rmlMod = 0;
+    if (mod & SDL_KMOD_CTRL)   rmlMod |= Rml::Input::KM_CTRL;
+    if (mod & SDL_KMOD_SHIFT)  rmlMod |= Rml::Input::KM_SHIFT;
+    if (mod & SDL_KMOD_ALT)    rmlMod |= Rml::Input::KM_ALT;
+    if (mod & SDL_KMOD_GUI)    rmlMod |= Rml::Input::KM_META;
+    if (mod & SDL_KMOD_CAPS)   rmlMod |= Rml::Input::KM_CAPSLOCK;
+    if (mod & SDL_KMOD_NUM)    rmlMod |= Rml::Input::KM_NUMLOCK;
+    if (mod & SDL_KMOD_SCROLL) rmlMod |= Rml::Input::KM_SCROLLLOCK;
+    return rmlMod;
+}
+
+} // namespace fabric

--- a/src/core/MeleeSystem.cc
+++ b/src/core/MeleeSystem.cc
@@ -1,0 +1,85 @@
+#include "fabric/core/MeleeSystem.hh"
+
+#include <algorithm>
+#include <cmath>
+
+namespace fabric {
+
+MeleeSystem::MeleeSystem(EventDispatcher& dispatcher) : dispatcher_(dispatcher) {}
+
+MeleeAttack MeleeSystem::createAttack(
+    const Vector3<float, Space::World>& playerPos,
+    const Vector3<float, Space::World>& facingDir,
+    const MeleeConfig& config) {
+
+    float ax = std::abs(facingDir.x);
+    float ay = std::abs(facingDir.y);
+    float az = std::abs(facingDir.z);
+
+    Vec3f center = playerPos;
+    Vec3f halfExtents;
+
+    // Snap to nearest world axis for AABB alignment
+    if (ax >= ay && ax >= az) {
+        float sign = (facingDir.x >= 0.0f) ? 1.0f : -1.0f;
+        center.x += sign * (config.reach / 2.0f);
+        halfExtents = Vec3f(config.reach / 2.0f, config.height / 2.0f, config.width / 2.0f);
+    } else if (ay >= ax && ay >= az) {
+        float sign = (facingDir.y >= 0.0f) ? 1.0f : -1.0f;
+        center.y += sign * (config.reach / 2.0f);
+        halfExtents = Vec3f(config.width / 2.0f, config.reach / 2.0f, config.width / 2.0f);
+    } else {
+        float sign = (facingDir.z >= 0.0f) ? 1.0f : -1.0f;
+        center.z += sign * (config.reach / 2.0f);
+        halfExtents = Vec3f(config.width / 2.0f, config.height / 2.0f, config.reach / 2.0f);
+    }
+
+    AABB hitbox(
+        Vec3f(center.x - halfExtents.x, center.y - halfExtents.y, center.z - halfExtents.z),
+        Vec3f(center.x + halfExtents.x, center.y + halfExtents.y, center.z + halfExtents.z));
+
+    float len = std::sqrt(facingDir.x * facingDir.x + facingDir.y * facingDir.y + facingDir.z * facingDir.z);
+    Vec3f direction = (len > 0.0f)
+        ? Vec3f(facingDir.x / len, facingDir.y / len, facingDir.z / len)
+        : Vec3f(0.0f, 0.0f, 1.0f);
+
+    return {hitbox, config.damage, config.knockback, direction};
+}
+
+std::vector<size_t> MeleeSystem::checkHits(
+    const MeleeAttack& attack,
+    const std::vector<AABB>& targetBounds) {
+
+    std::vector<size_t> hits;
+    for (size_t i = 0; i < targetBounds.size(); ++i) {
+        if (attack.hitbox.intersects(targetBounds[i]))
+            hits.push_back(i);
+    }
+    return hits;
+}
+
+bool MeleeSystem::canAttack(float cooldownRemaining) const {
+    return cooldownRemaining <= 0.0f;
+}
+
+float MeleeSystem::updateCooldown(float remaining, float dt) const {
+    return std::max(0.0f, remaining - dt);
+}
+
+void MeleeSystem::emitDamageEvent(
+    const Vector3<float, Space::World>& targetPos,
+    float damage,
+    const Vector3<float, Space::World>& knockbackDir) {
+
+    Event e("melee_damage", "MeleeSystem");
+    e.setData<float>("x", targetPos.x);
+    e.setData<float>("y", targetPos.y);
+    e.setData<float>("z", targetPos.z);
+    e.setData<float>("damage", damage);
+    e.setData<float>("knockback_x", knockbackDir.x);
+    e.setData<float>("knockback_y", knockbackDir.y);
+    e.setData<float>("knockback_z", knockbackDir.z);
+    dispatcher_.dispatchEvent(e);
+}
+
+} // namespace fabric

--- a/src/core/MovementFSM.cc
+++ b/src/core/MovementFSM.cc
@@ -1,0 +1,83 @@
+#include "fabric/core/MovementFSM.hh"
+#include "fabric/core/Log.hh"
+
+namespace fabric {
+
+std::string MovementFSM::stateToString(CharacterState state) {
+    switch (state) {
+        case CharacterState::Grounded:    return "Grounded";
+        case CharacterState::Falling:     return "Falling";
+        case CharacterState::Jumping:     return "Jumping";
+        case CharacterState::Climbing:    return "Climbing";
+        case CharacterState::Swimming:    return "Swimming";
+        case CharacterState::WallRunning: return "WallRunning";
+        case CharacterState::Hanging:     return "Hanging";
+        case CharacterState::Flying:      return "Flying";
+        case CharacterState::Sliding:     return "Sliding";
+        case CharacterState::Ragdoll:     return "Ragdoll";
+        case CharacterState::Dashing:     return "Dashing";
+        case CharacterState::Boosting:    return "Boosting";
+        default:                          return "Unknown";
+    }
+}
+
+MovementFSM::MovementFSM()
+    : sm_(std::make_unique<StateMachine<CharacterState>>(CharacterState::Grounded, stateToString)) {
+
+    // Sprint 5b active transitions: Grounded, Falling, Jumping, Flying, Dashing, Boosting
+    sm_->addTransition(CharacterState::Grounded, CharacterState::Jumping);
+    sm_->addTransition(CharacterState::Grounded, CharacterState::Falling);
+    sm_->addTransition(CharacterState::Grounded, CharacterState::Flying);
+    sm_->addTransition(CharacterState::Grounded, CharacterState::Dashing);
+
+    sm_->addTransition(CharacterState::Jumping, CharacterState::Falling);
+    sm_->addTransition(CharacterState::Jumping, CharacterState::Flying);
+
+    sm_->addTransition(CharacterState::Falling, CharacterState::Grounded);
+    sm_->addTransition(CharacterState::Falling, CharacterState::Flying);
+
+    sm_->addTransition(CharacterState::Flying, CharacterState::Falling);
+    sm_->addTransition(CharacterState::Flying, CharacterState::Grounded);
+    sm_->addTransition(CharacterState::Flying, CharacterState::Boosting);
+
+    sm_->addTransition(CharacterState::Dashing, CharacterState::Grounded);
+    sm_->addTransition(CharacterState::Dashing, CharacterState::Falling);
+
+    sm_->addTransition(CharacterState::Boosting, CharacterState::Flying);
+    sm_->addTransition(CharacterState::Boosting, CharacterState::Falling);
+}
+
+bool MovementFSM::tryTransition(CharacterState target) {
+    CharacterState current = sm_->getState();
+    if (!sm_->isValidTransition(current, target)) {
+        FABRIC_LOG_DEBUG("Movement transition rejected: {} -> {}", stateToString(current), stateToString(target));
+        return false;
+    }
+    sm_->setState(target);
+    return true;
+}
+
+CharacterState MovementFSM::currentState() const {
+    return sm_->getState();
+}
+
+bool MovementFSM::isGrounded() const {
+    return sm_->getState() == CharacterState::Grounded;
+}
+
+bool MovementFSM::isAirborne() const {
+    CharacterState s = sm_->getState();
+    return s == CharacterState::Jumping || s == CharacterState::Falling;
+}
+
+bool MovementFSM::isFlying() const {
+    CharacterState s = sm_->getState();
+    return s == CharacterState::Flying || s == CharacterState::Boosting;
+}
+
+bool MovementFSM::canDash() const {
+    CharacterState s = sm_->getState();
+    return s == CharacterState::Grounded;
+}
+
+} // namespace fabric

--- a/src/core/TransitionController.cc
+++ b/src/core/TransitionController.cc
@@ -1,0 +1,59 @@
+#include "fabric/core/TransitionController.hh"
+#include <cmath>
+
+namespace fabric {
+
+TransitionController::TransitionResult TransitionController::enterFlight(
+    const Vec3f& currentVelocity,
+    float upwardImpulse,
+    float momentumScale) {
+
+    TransitionResult result;
+    result.velocity = Vec3f(
+        currentVelocity.x * momentumScale,
+        upwardImpulse,
+        currentVelocity.z * momentumScale);
+    result.newState = CharacterState::Flying;
+    return result;
+}
+
+TransitionController::TransitionResult TransitionController::exitFlight(
+    const Vec3f& currentVelocity,
+    const Vec3f& position,
+    const ChunkedGrid<float>& grid,
+    float groundCheckDistance,
+    float densityThreshold) {
+
+    TransitionResult result;
+    result.velocity = currentVelocity;
+
+    if (checkGroundBelow(position, grid, groundCheckDistance, densityThreshold)) {
+        result.newState = CharacterState::Grounded;
+        result.velocity.y = 0.0f;
+    } else {
+        result.newState = CharacterState::Falling;
+    }
+
+    return result;
+}
+
+bool TransitionController::checkGroundBelow(
+    const Vec3f& position,
+    const ChunkedGrid<float>& grid,
+    float distance,
+    float densityThreshold) const {
+
+    int x = static_cast<int>(std::floor(position.x));
+    int z = static_cast<int>(std::floor(position.z));
+    int startY = static_cast<int>(std::floor(position.y)) - 1;
+    int endY = static_cast<int>(std::floor(position.y - distance));
+
+    for (int y = startY; y >= endY; --y) {
+        if (grid.get(x, y, z) >= densityThreshold) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace fabric

--- a/src/core/VoxelInteraction.cc
+++ b/src/core/VoxelInteraction.cc
@@ -1,0 +1,78 @@
+#include "fabric/core/VoxelInteraction.hh"
+#include "fabric/core/ChunkMeshManager.hh"
+
+namespace fabric {
+
+VoxelInteraction::VoxelInteraction(DensityField& density, EssenceField& essence, EventDispatcher& dispatcher)
+    : density_(density), essence_(essence), dispatcher_(dispatcher) {}
+
+InteractionResult VoxelInteraction::createMatter(
+    const VoxelHit& hit,
+    float density,
+    const Vector4<float, Space::World>& essenceColor) {
+
+    // Place adjacent to hit face via normal
+    int x = hit.x + hit.nx;
+    int y = hit.y + hit.ny;
+    int z = hit.z + hit.nz;
+
+    density_.write(x, y, z, density);
+    essence_.write(x, y, z, essenceColor);
+
+    int cx = x >> kChunkShift;
+    int cy = y >> kChunkShift;
+    int cz = z >> kChunkShift;
+    ChunkMeshManager::emitVoxelChanged(dispatcher_, cx, cy, cz);
+
+    return {true, x, y, z, cx, cy, cz};
+}
+
+InteractionResult VoxelInteraction::destroyMatter(const VoxelHit& hit) {
+    int x = hit.x;
+    int y = hit.y;
+    int z = hit.z;
+
+    density_.write(x, y, z, 0.0f);
+
+    int cx = x >> kChunkShift;
+    int cy = y >> kChunkShift;
+    int cz = z >> kChunkShift;
+    ChunkMeshManager::emitVoxelChanged(dispatcher_, cx, cy, cz);
+
+    return {true, x, y, z, cx, cy, cz};
+}
+
+InteractionResult VoxelInteraction::createMatterAt(
+    const ChunkedGrid<float>& grid,
+    float ox, float oy, float oz,
+    float dx, float dy, float dz,
+    float density,
+    const Vector4<float, Space::World>& essenceColor,
+    float maxDistance) {
+
+    auto hit = castRay(grid, ox, oy, oz, dx, dy, dz, maxDistance);
+    if (!hit.has_value())
+        return {false, 0, 0, 0, 0, 0, 0};
+    return createMatter(*hit, density, essenceColor);
+}
+
+InteractionResult VoxelInteraction::destroyMatterAt(
+    const ChunkedGrid<float>& grid,
+    float ox, float oy, float oz,
+    float dx, float dy, float dz,
+    float maxDistance) {
+
+    auto hit = castRay(grid, ox, oy, oz, dx, dy, dz, maxDistance);
+    if (!hit.has_value())
+        return {false, 0, 0, 0, 0, 0, 0};
+    return destroyMatter(*hit);
+}
+
+bool VoxelInteraction::wouldOverlap(int vx, int vy, int vz, const AABB& playerBounds) {
+    AABB voxelBounds(
+        Vec3f(static_cast<float>(vx), static_cast<float>(vy), static_cast<float>(vz)),
+        Vec3f(static_cast<float>(vx + 1), static_cast<float>(vy + 1), static_cast<float>(vz + 1)));
+    return voxelBounds.intersects(playerBounds);
+}
+
+} // namespace fabric

--- a/tests/unit/core/CMakeLists.txt
+++ b/tests/unit/core/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(UnitTests
   RenderingTest.cc
   CameraTest.cc
   InputManagerTest.cc
+  InputRouterTest.cc
   SceneViewTest.cc
   ECSTest.cc
   ChunkedGridTest.cc
@@ -26,6 +27,14 @@ target_sources(UnitTests
   VoxelRaycastTest.cc
   ChunkStreamingTest.cc
   ChunkMeshManagerTest.cc
+  MovementFSMTest.cc
+  CharacterControllerTest.cc
+  CameraControllerTest.cc
+  VoxelInteractionTest.cc
+  MeleeSystemTest.cc
+  FlightControllerTest.cc
+  TransitionControllerTest.cc
+  DashControllerTest.cc
 )
 
 set_source_files_properties(

--- a/tests/unit/core/CameraControllerTest.cc
+++ b/tests/unit/core/CameraControllerTest.cc
@@ -1,0 +1,254 @@
+#include "fabric/core/CameraController.hh"
+#include <cmath>
+#include <gtest/gtest.h>
+#include <numbers>
+
+using namespace fabric;
+
+class CameraControllerTest : public ::testing::Test {
+  protected:
+    Camera camera;
+
+    void SetUp() override {
+        camera.setPerspective(60.0f, 16.0f / 9.0f, 0.1f, 1000.0f, true);
+    }
+};
+
+// -- First person tests --
+
+TEST_F(CameraControllerTest, FirstPersonPositionAtEyeHeight) {
+    CameraController ctrl(camera);
+    ctrl.setMode(CameraMode::FirstPerson);
+
+    Vector3<float, Space::World> target(10.0f, 0.0f, 5.0f);
+    ctrl.update(target, 0.016f);
+
+    auto pos = ctrl.position();
+    EXPECT_FLOAT_EQ(pos.x, 10.0f);
+    EXPECT_FLOAT_EQ(pos.y, 1.6f); // default eyeHeight
+    EXPECT_FLOAT_EQ(pos.z, 5.0f);
+}
+
+TEST_F(CameraControllerTest, FirstPersonMouseRotatesView) {
+    CameraController ctrl(camera);
+    ctrl.setMode(CameraMode::FirstPerson);
+
+    float initialYaw = ctrl.yaw();
+    float initialPitch = ctrl.pitch();
+
+    ctrl.processMouseInput(100.0f, 50.0f);
+
+    EXPECT_NE(ctrl.yaw(), initialYaw);
+    EXPECT_NE(ctrl.pitch(), initialPitch);
+}
+
+TEST_F(CameraControllerTest, FirstPersonPitchClampedAt89) {
+    CameraController ctrl(camera);
+    ctrl.setMode(CameraMode::FirstPerson);
+
+    // Push pitch way beyond limits
+    ctrl.setPitch(100.0f);
+    EXPECT_FLOAT_EQ(ctrl.pitch(), 89.0f);
+
+    ctrl.setPitch(-100.0f);
+    EXPECT_FLOAT_EQ(ctrl.pitch(), -89.0f);
+}
+
+// -- Third person tests --
+
+TEST_F(CameraControllerTest, ThirdPersonCameraBehindPlayer) {
+    CameraController ctrl(camera);
+    ctrl.setMode(CameraMode::ThirdPerson);
+    ctrl.setYaw(0.0f);
+    ctrl.setPitch(0.0f);
+
+    Vector3<float, Space::World> target(0.0f, 0.0f, 0.0f);
+    // Run several frames to let spring arm converge
+    for (int i = 0; i < 100; ++i)
+        ctrl.update(target, 0.016f);
+
+    auto pos = ctrl.position();
+    // At yaw=0, pitch=0, forward = +Z, so camera should be behind = -Z
+    EXPECT_NEAR(pos.x, 0.0f, 0.1f);
+    EXPECT_NEAR(pos.y, 1.6f, 0.1f);
+    EXPECT_LT(pos.z, 0.0f); // Behind the player
+    EXPECT_NEAR(pos.z, -8.0f + 1.6f * 0.0f, 1.0f); // Roughly at -orbitDistance on Z
+}
+
+TEST_F(CameraControllerTest, SpringArmShortensOnCollision) {
+    CameraConfig cfg;
+    cfg.orbitDistance = 8.0f;
+    cfg.springArmSmoothing = 1000.0f; // High smoothing for instant convergence
+    CameraController ctrl(camera, cfg);
+    ctrl.setMode(CameraMode::ThirdPerson);
+    ctrl.setYaw(0.0f);
+    ctrl.setPitch(0.0f);
+
+    // Build a grid with a wall 3 units behind the player
+    ChunkedGrid<float> grid;
+    // Forward is +Z at yaw=0, so "behind" is -Z
+    // Fill a wall at z=-3
+    for (int x = -5; x <= 5; ++x) {
+        for (int y = -5; y <= 15; ++y) {
+            grid.set(x, y, -3, 1.0f);
+        }
+    }
+
+    Vector3<float, Space::World> target(0.0f, 0.0f, 0.0f);
+    for (int i = 0; i < 50; ++i)
+        ctrl.update(target, 0.016f, &grid);
+
+    auto pos = ctrl.position();
+    // Camera should be closer than full orbit distance (8) due to wall at z=-3
+    float dist = std::sqrt(pos.x * pos.x + (pos.y - 1.6f) * (pos.y - 1.6f) + pos.z * pos.z);
+    EXPECT_LT(dist, 4.0f);
+    EXPECT_GT(dist, cfg.orbitMinDistance - 0.1f);
+}
+
+TEST_F(CameraControllerTest, SpringArmReturnsToFullDistance) {
+    CameraConfig cfg;
+    cfg.springArmSmoothing = 50.0f;
+    CameraController ctrl(camera, cfg);
+    ctrl.setMode(CameraMode::ThirdPerson);
+    ctrl.setYaw(0.0f);
+    ctrl.setPitch(0.0f);
+
+    // First: update with a wall nearby (simulate collision)
+    ChunkedGrid<float> gridWithWall;
+    for (int x = -5; x <= 5; ++x) {
+        for (int y = -5; y <= 15; ++y) {
+            gridWithWall.set(x, y, -2, 1.0f);
+        }
+    }
+
+    Vector3<float, Space::World> target(0.0f, 0.0f, 0.0f);
+    for (int i = 0; i < 50; ++i)
+        ctrl.update(target, 0.016f, &gridWithWall);
+
+    // Camera should be close
+    auto closerPos = ctrl.position();
+    float closerDist = std::abs(closerPos.z);
+
+    // Now update without grid (no collision) and let spring arm recover
+    for (int i = 0; i < 200; ++i)
+        ctrl.update(target, 0.016f);
+
+    auto farPos = ctrl.position();
+    float farDist = std::abs(farPos.z);
+
+    EXPECT_GT(farDist, closerDist);
+}
+
+// -- Mode switching --
+
+TEST_F(CameraControllerTest, ModeSwitchFirstToThird) {
+    CameraController ctrl(camera);
+    EXPECT_EQ(ctrl.mode(), CameraMode::FirstPerson);
+
+    ctrl.setMode(CameraMode::ThirdPerson);
+    EXPECT_EQ(ctrl.mode(), CameraMode::ThirdPerson);
+}
+
+TEST_F(CameraControllerTest, ModeSwitchThirdToFirst) {
+    CameraController ctrl(camera);
+    ctrl.setMode(CameraMode::ThirdPerson);
+    ctrl.setMode(CameraMode::FirstPerson);
+    EXPECT_EQ(ctrl.mode(), CameraMode::FirstPerson);
+}
+
+// -- Direction vectors --
+
+TEST_F(CameraControllerTest, DirectionVectorsOrthogonal) {
+    CameraController ctrl(camera);
+    ctrl.setYaw(45.0f);
+    ctrl.setPitch(30.0f);
+
+    auto fwd = ctrl.forward();
+    auto rt = ctrl.right();
+    auto u = ctrl.up();
+
+    EXPECT_NEAR(fwd.dot(rt), 0.0f, 1e-5f);
+    EXPECT_NEAR(fwd.dot(u), 0.0f, 1e-5f);
+    EXPECT_NEAR(rt.dot(u), 0.0f, 1e-5f);
+}
+
+TEST_F(CameraControllerTest, DirectionVectorsUnitLength) {
+    CameraController ctrl(camera);
+    ctrl.setYaw(120.0f);
+    ctrl.setPitch(-45.0f);
+
+    EXPECT_NEAR(ctrl.forward().length(), 1.0f, 1e-5f);
+    EXPECT_NEAR(ctrl.right().length(), 1.0f, 1e-5f);
+    EXPECT_NEAR(ctrl.up().length(), 1.0f, 1e-5f);
+}
+
+// -- Yaw wrapping --
+
+TEST_F(CameraControllerTest, YawWrapsAround360) {
+    CameraController ctrl(camera);
+    ctrl.setYaw(370.0f);
+    EXPECT_NEAR(ctrl.yaw(), 10.0f, 1e-3f);
+
+    ctrl.setYaw(-10.0f);
+    EXPECT_NEAR(ctrl.yaw(), 350.0f, 1e-3f);
+}
+
+// -- Pitch unlock --
+
+TEST_F(CameraControllerTest, PitchUnlockAllowsFullRotation) {
+    CameraController ctrl(camera);
+    ctrl.setUnlockPitch(true);
+
+    ctrl.setPitch(100.0f);
+    EXPECT_NEAR(ctrl.pitch(), 100.0f, 1e-3f);
+
+    ctrl.setPitch(270.0f);
+    EXPECT_NEAR(ctrl.pitch(), 270.0f, 1e-3f);
+}
+
+// -- Null grid skips collision --
+
+TEST_F(CameraControllerTest, NullGridSkipsCollision) {
+    CameraController ctrl(camera);
+    ctrl.setMode(CameraMode::ThirdPerson);
+    ctrl.setYaw(0.0f);
+    ctrl.setPitch(0.0f);
+
+    Vector3<float, Space::World> target(0.0f, 0.0f, 0.0f);
+    // Should not crash with nullptr grid
+    for (int i = 0; i < 50; ++i)
+        ctrl.update(target, 0.016f, nullptr);
+
+    auto pos = ctrl.position();
+    // Camera should approach full orbit distance
+    float dist = std::abs(pos.z);
+    EXPECT_GT(dist, 5.0f);
+}
+
+// -- Custom eye height --
+
+TEST_F(CameraControllerTest, CustomEyeHeight) {
+    CameraConfig cfg;
+    cfg.eyeHeight = 3.0f;
+    CameraController ctrl(camera, cfg);
+    ctrl.setMode(CameraMode::FirstPerson);
+
+    Vector3<float, Space::World> target(0.0f, 0.0f, 0.0f);
+    ctrl.update(target, 0.016f);
+
+    EXPECT_FLOAT_EQ(ctrl.position().y, 3.0f);
+}
+
+// -- Forward direction matches yaw at zero pitch --
+
+TEST_F(CameraControllerTest, ForwardMatchesYawAtZeroPitch) {
+    CameraController ctrl(camera);
+    ctrl.setYaw(0.0f);
+    ctrl.setPitch(0.0f);
+
+    auto fwd = ctrl.forward();
+    // At yaw=0, pitch=0, left-handed: forward should be +Z
+    EXPECT_NEAR(fwd.x, 0.0f, 1e-5f);
+    EXPECT_NEAR(fwd.y, 0.0f, 1e-5f);
+    EXPECT_NEAR(fwd.z, 1.0f, 1e-5f);
+}

--- a/tests/unit/core/CharacterControllerTest.cc
+++ b/tests/unit/core/CharacterControllerTest.cc
@@ -1,0 +1,182 @@
+#include <gtest/gtest.h>
+#include "fabric/core/CharacterController.hh"
+
+using namespace fabric;
+
+class CharacterControllerTest : public ::testing::Test {
+  protected:
+    // 1x2x1 character (width, height, depth)
+    CharacterController controller{1.0f, 2.0f, 1.0f};
+    ChunkedGrid<float> grid;
+
+    void fillFloor(int y, int xMin, int xMax, int zMin, int zMax) {
+        for (int z = zMin; z <= zMax; ++z)
+            for (int x = xMin; x <= xMax; ++x)
+                grid.set(x, y, z, 1.0f);
+    }
+};
+
+TEST_F(CharacterControllerTest, WalkOnFlatSurface) {
+    // Flat floor at y=0, character stands at y=1
+    fillFloor(0, -5, 5, -5, 5);
+    Vec3f pos(0.0f, 1.0f, 0.0f);
+    Vec3f move(1.0f, 0.0f, 0.0f);
+
+    auto result = controller.move(pos, move, grid);
+    EXPECT_FALSE(result.hitX);
+    EXPECT_FALSE(result.hitZ);
+    EXPECT_TRUE(result.onGround);
+    EXPECT_NEAR(result.resolvedPosition.x, 1.0f, 0.01f);
+    EXPECT_NEAR(result.resolvedPosition.y, 1.0f, 0.01f);
+}
+
+TEST_F(CharacterControllerTest, CollideWithWallX) {
+    fillFloor(0, -5, 5, -5, 5);
+    // Wall at x=3, y=1..2
+    grid.set(3, 1, 0, 1.0f);
+    grid.set(3, 2, 0, 1.0f);
+
+    Vec3f pos(2.0f, 1.0f, 0.0f);
+    Vec3f move(2.0f, 0.0f, 0.0f);
+
+    auto result = controller.move(pos, move, grid);
+    EXPECT_TRUE(result.hitX);
+    EXPECT_NEAR(result.resolvedPosition.x, 2.0f, 0.01f);
+}
+
+TEST_F(CharacterControllerTest, FallOffEdge) {
+    // Floor from x=-5 to x=2 only
+    fillFloor(0, -5, 2, -5, 5);
+
+    Vec3f pos(2.0f, 1.0f, 0.0f);
+    Vec3f move(2.0f, 0.0f, 0.0f);
+
+    auto result = controller.move(pos, move, grid);
+    EXPECT_FALSE(result.onGround);
+    EXPECT_NEAR(result.resolvedPosition.x, 4.0f, 0.01f);
+}
+
+TEST_F(CharacterControllerTest, StepUpOntoOneLedge) {
+    fillFloor(0, -5, 5, -5, 5);
+    // 1-block ledge at x=3 y=1
+    grid.set(3, 1, 0, 1.0f);
+
+    Vec3f pos(2.0f, 1.0f, 0.0f);
+    Vec3f move(2.0f, 0.0f, 0.0f);
+
+    auto result = controller.move(pos, move, grid);
+    // Should step up by 1
+    EXPECT_FALSE(result.hitX);
+    EXPECT_NEAR(result.resolvedPosition.y, 2.0f, 0.01f);
+    EXPECT_NEAR(result.resolvedPosition.x, 4.0f, 0.01f);
+}
+
+TEST_F(CharacterControllerTest, CannotStepUpTwoBlockWall) {
+    fillFloor(0, -5, 5, -5, 5);
+    // 2-block wall at x=3 y=1,2
+    grid.set(3, 1, 0, 1.0f);
+    grid.set(3, 2, 0, 1.0f);
+
+    Vec3f pos(2.0f, 1.0f, 0.0f);
+    Vec3f move(2.0f, 0.0f, 0.0f);
+
+    auto result = controller.move(pos, move, grid);
+    EXPECT_TRUE(result.hitX);
+    EXPECT_NEAR(result.resolvedPosition.x, 2.0f, 0.01f);
+}
+
+TEST_F(CharacterControllerTest, GravityPullsDown) {
+    // No floor, character in air
+    Vec3f pos(0.0f, 5.0f, 0.0f);
+    Vec3f move(0.0f, -2.0f, 0.0f);
+
+    auto result = controller.move(pos, move, grid);
+    EXPECT_FALSE(result.onGround);
+    EXPECT_NEAR(result.resolvedPosition.y, 3.0f, 0.01f);
+}
+
+TEST_F(CharacterControllerTest, GravityStopsOnGround) {
+    fillFloor(0, -5, 5, -5, 5);
+    Vec3f pos(0.0f, 2.0f, 0.0f);
+    Vec3f move(0.0f, -3.0f, 0.0f);
+
+    auto result = controller.move(pos, move, grid);
+    EXPECT_TRUE(result.onGround);
+    EXPECT_TRUE(result.hitY);
+    EXPECT_NEAR(result.resolvedPosition.y, 1.0f, 0.01f);
+}
+
+TEST_F(CharacterControllerTest, NegativeCoordinates) {
+    // Floor at y=-1 in negative space
+    for (int x = -10; x <= -5; ++x)
+        for (int z = -10; z <= -5; ++z)
+            grid.set(x, -1, z, 1.0f);
+
+    Vec3f pos(-7.0f, 0.0f, -7.0f);
+    Vec3f move(1.0f, 0.0f, 1.0f);
+
+    auto result = controller.move(pos, move, grid);
+    EXPECT_TRUE(result.onGround);
+    EXPECT_NEAR(result.resolvedPosition.x, -6.0f, 0.01f);
+    EXPECT_NEAR(result.resolvedPosition.z, -6.0f, 0.01f);
+}
+
+TEST_F(CharacterControllerTest, CollideWithWallZ) {
+    fillFloor(0, -5, 5, -5, 5);
+    // Wall at z=3, y=1..2
+    grid.set(0, 1, 3, 1.0f);
+    grid.set(0, 2, 3, 1.0f);
+
+    Vec3f pos(0.0f, 1.0f, 2.0f);
+    Vec3f move(0.0f, 0.0f, 2.0f);
+
+    auto result = controller.move(pos, move, grid);
+    EXPECT_TRUE(result.hitZ);
+    EXPECT_NEAR(result.resolvedPosition.z, 2.0f, 0.01f);
+}
+
+TEST_F(CharacterControllerTest, AABBCorrect) {
+    Vec3f pos(5.0f, 3.0f, 5.0f);
+    auto box = controller.getAABB(pos);
+
+    EXPECT_NEAR(box.min.x, 4.5f, 0.001f);
+    EXPECT_NEAR(box.min.y, 3.0f, 0.001f);
+    EXPECT_NEAR(box.min.z, 4.5f, 0.001f);
+    EXPECT_NEAR(box.max.x, 5.5f, 0.001f);
+    EXPECT_NEAR(box.max.y, 5.0f, 0.001f);
+    EXPECT_NEAR(box.max.z, 5.5f, 0.001f);
+}
+
+TEST_F(CharacterControllerTest, StepHeightAccessor) {
+    EXPECT_NEAR(controller.stepHeight(), 1.0f, 0.001f);
+    controller.setStepHeight(0.5f);
+    EXPECT_NEAR(controller.stepHeight(), 0.5f, 0.001f);
+}
+
+TEST_F(CharacterControllerTest, NoDisplacementStaysInPlace) {
+    fillFloor(0, -5, 5, -5, 5);
+    Vec3f pos(0.0f, 1.0f, 0.0f);
+    Vec3f move(0.0f, 0.0f, 0.0f);
+
+    auto result = controller.move(pos, move, grid);
+    EXPECT_TRUE(result.onGround);
+    EXPECT_FALSE(result.hitX);
+    EXPECT_FALSE(result.hitY);
+    EXPECT_FALSE(result.hitZ);
+    EXPECT_NEAR(result.resolvedPosition.x, 0.0f, 0.01f);
+    EXPECT_NEAR(result.resolvedPosition.y, 1.0f, 0.01f);
+}
+
+TEST_F(CharacterControllerTest, DensityBelowThresholdIsPassable) {
+    // Voxel with density below threshold should not block
+    grid.set(3, 1, 0, 0.3f);
+    grid.set(3, 2, 0, 0.3f);
+    fillFloor(0, -5, 5, -5, 5);
+
+    Vec3f pos(2.0f, 1.0f, 0.0f);
+    Vec3f move(2.0f, 0.0f, 0.0f);
+
+    auto result = controller.move(pos, move, grid);
+    EXPECT_FALSE(result.hitX);
+    EXPECT_NEAR(result.resolvedPosition.x, 4.0f, 0.01f);
+}

--- a/tests/unit/core/DashControllerTest.cc
+++ b/tests/unit/core/DashControllerTest.cc
@@ -1,0 +1,143 @@
+#include <gtest/gtest.h>
+#include "fabric/core/DashController.hh"
+#include <cmath>
+
+using namespace fabric;
+
+class DashControllerTest : public ::testing::Test {
+  protected:
+    DashController dc;
+    DashState state;
+    CharacterConfig config;
+};
+
+// startDash tests
+
+TEST_F(DashControllerTest, StartDashSucceedsOffCooldown) {
+    bool ok = dc.startDash(state, config, false);
+
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(state.active);
+    EXPECT_NEAR(state.durationRemaining, config.dashDuration, 0.001f);
+}
+
+TEST_F(DashControllerTest, StartDashSetsCooldown) {
+    dc.startDash(state, config, false);
+
+    EXPECT_NEAR(state.cooldownRemaining, config.dashCooldown, 0.001f);
+}
+
+TEST_F(DashControllerTest, StartDashFailsDuringCooldown) {
+    state.cooldownRemaining = 0.5f;
+
+    bool ok = dc.startDash(state, config, false);
+    EXPECT_FALSE(ok);
+    EXPECT_FALSE(state.active);
+}
+
+TEST_F(DashControllerTest, StartBoostUsesBoostCooldown) {
+    dc.startDash(state, config, true);
+
+    EXPECT_NEAR(state.cooldownRemaining, config.boostCooldown, 0.001f);
+}
+
+// update tests
+
+TEST_F(DashControllerTest, UpdateReturnsDisplacement) {
+    dc.startDash(state, config, false);
+
+    Vec3f dir(1.0f, 0.0f, 0.0f);
+    float dt = 1.0f / 60.0f;
+    auto result = dc.update(state, config, dir, dt, false);
+
+    EXPECT_TRUE(result.active);
+    EXPECT_NEAR(result.displacement.x, config.dashSpeed * dt, 0.01f);
+    EXPECT_NEAR(result.displacement.y, 0.0f, 0.001f);
+    EXPECT_NEAR(result.displacement.z, 0.0f, 0.001f);
+}
+
+TEST_F(DashControllerTest, BoostUsesBoostSpeed) {
+    dc.startDash(state, config, true);
+
+    Vec3f dir(0.0f, 1.0f, 0.0f);
+    float dt = 1.0f / 60.0f;
+    auto result = dc.update(state, config, dir, dt, true);
+
+    EXPECT_NEAR(result.displacement.y, config.boostSpeed * dt, 0.01f);
+}
+
+TEST_F(DashControllerTest, UpdateInactiveReturnsZero) {
+    Vec3f dir(1.0f, 0.0f, 0.0f);
+    auto result = dc.update(state, config, dir, 1.0f / 60.0f, false);
+
+    EXPECT_FALSE(result.active);
+    EXPECT_NEAR(result.displacement.x, 0.0f, 0.001f);
+}
+
+TEST_F(DashControllerTest, DashAutoEndsAfterDuration) {
+    dc.startDash(state, config, false);
+
+    Vec3f dir(1.0f, 0.0f, 0.0f);
+    // Tick past entire duration in one step
+    auto result = dc.update(state, config, dir, config.dashDuration + 0.01f, false);
+
+    EXPECT_TRUE(result.justFinished);
+    EXPECT_FALSE(result.active);
+    EXPECT_FALSE(state.active);
+}
+
+TEST_F(DashControllerTest, DashNotFinishedMidDuration) {
+    dc.startDash(state, config, false);
+
+    Vec3f dir(1.0f, 0.0f, 0.0f);
+    auto result = dc.update(state, config, dir, config.dashDuration * 0.5f, false);
+
+    EXPECT_TRUE(result.active);
+    EXPECT_FALSE(result.justFinished);
+    EXPECT_TRUE(state.active);
+}
+
+// updateCooldown tests
+
+TEST_F(DashControllerTest, CooldownDecrementsOverTime) {
+    dc.startDash(state, config, false);
+    float initial = state.cooldownRemaining;
+
+    dc.updateCooldown(state, 0.1f);
+    EXPECT_NEAR(state.cooldownRemaining, initial - 0.1f, 0.001f);
+}
+
+TEST_F(DashControllerTest, CooldownClampsToZero) {
+    state.cooldownRemaining = 0.05f;
+
+    dc.updateCooldown(state, 1.0f);
+    EXPECT_NEAR(state.cooldownRemaining, 0.0f, 0.001f);
+}
+
+TEST_F(DashControllerTest, CooldownExpiresAllowsNewDash) {
+    dc.startDash(state, config, false);
+
+    // Expire the dash
+    dc.update(state, config, Vec3f(1.0f, 0.0f, 0.0f), config.dashDuration + 0.01f, false);
+
+    // Expire cooldown
+    dc.updateCooldown(state, config.dashCooldown + 0.01f);
+    EXPECT_NEAR(state.cooldownRemaining, 0.0f, 0.02f);
+
+    bool ok = dc.startDash(state, config, false);
+    EXPECT_TRUE(ok);
+}
+
+TEST_F(DashControllerTest, DiagonalDashDisplacement) {
+    dc.startDash(state, config, false);
+
+    // Diagonal direction (not normalized -- caller is responsible)
+    Vec3f dir(0.707f, 0.0f, 0.707f);
+    float dt = 1.0f / 60.0f;
+    auto result = dc.update(state, config, dir, dt, false);
+
+    float expectedX = 0.707f * config.dashSpeed * dt;
+    float expectedZ = 0.707f * config.dashSpeed * dt;
+    EXPECT_NEAR(result.displacement.x, expectedX, 0.01f);
+    EXPECT_NEAR(result.displacement.z, expectedZ, 0.01f);
+}

--- a/tests/unit/core/FlightControllerTest.cc
+++ b/tests/unit/core/FlightControllerTest.cc
@@ -1,0 +1,180 @@
+#include <gtest/gtest.h>
+#include "fabric/core/FlightController.hh"
+#include <cmath>
+
+using namespace fabric;
+
+class FlightControllerTest : public ::testing::Test {
+  protected:
+    // 1x2x1 character
+    FlightController controller{1.0f, 2.0f, 1.0f};
+    ChunkedGrid<float> grid;
+
+    void fillSlab(int y, int xMin, int xMax, int zMin, int zMax) {
+        for (int z = zMin; z <= zMax; ++z)
+            for (int x = xMin; x <= xMax; ++x)
+                grid.set(x, y, z, 1.0f);
+    }
+};
+
+TEST_F(FlightControllerTest, FlyForwardEmptySpace) {
+    Vec3f pos(0.0f, 5.0f, 0.0f);
+    Vec3f disp(0.0f, 0.0f, 1.0f);
+
+    auto result = controller.move(pos, disp, grid);
+    EXPECT_FALSE(result.hitX);
+    EXPECT_FALSE(result.hitY);
+    EXPECT_FALSE(result.hitZ);
+    EXPECT_NEAR(result.resolvedPosition.z, 1.0f, 0.01f);
+}
+
+TEST_F(FlightControllerTest, FlyUpEmptySpace) {
+    Vec3f pos(0.0f, 5.0f, 0.0f);
+    Vec3f disp(0.0f, 2.0f, 0.0f);
+
+    auto result = controller.move(pos, disp, grid);
+    EXPECT_NEAR(result.resolvedPosition.y, 7.0f, 0.01f);
+}
+
+TEST_F(FlightControllerTest, CollideWithWallX) {
+    // Wall at x=3, character half-width=0.5
+    grid.set(3, 5, 0, 1.0f);
+    grid.set(3, 6, 0, 1.0f);
+
+    // pos.x=2.5 + disp 0.5 = 3.0, AABB max.x=3.5 overlaps voxel at x=3
+    Vec3f pos(2.5f, 5.0f, 0.0f);
+    Vec3f disp(0.5f, 0.0f, 0.0f);
+
+    auto result = controller.move(pos, disp, grid);
+    EXPECT_TRUE(result.hitX);
+    EXPECT_NEAR(result.resolvedPosition.x, 2.5f, 0.01f);
+}
+
+TEST_F(FlightControllerTest, CollideWithCeiling) {
+    // Ceiling at y=10, character height=2.0
+    fillSlab(10, -5, 5, -5, 5);
+
+    // pos.y=8.0, AABB max.y=10.0. disp.y=0.5 puts max.y=10.5 overlapping y=10
+    Vec3f pos(0.0f, 8.0f, 0.0f);
+    Vec3f disp(0.0f, 0.5f, 0.0f);
+
+    auto result = controller.move(pos, disp, grid);
+    EXPECT_TRUE(result.hitY);
+    EXPECT_NEAR(result.resolvedPosition.y, 8.0f, 0.01f);
+}
+
+TEST_F(FlightControllerTest, CollideWithFloor) {
+    fillSlab(3, -5, 5, -5, 5);
+
+    // pos.y=4.0 (feet at 4), disp.y=-1.5 puts feet at 2.5, overlaps voxel at y=3
+    Vec3f pos(0.0f, 4.0f, 0.0f);
+    Vec3f disp(0.0f, -1.5f, 0.0f);
+
+    auto result = controller.move(pos, disp, grid);
+    EXPECT_TRUE(result.hitY);
+    EXPECT_NEAR(result.resolvedPosition.y, 4.0f, 0.01f);
+}
+
+TEST_F(FlightControllerTest, SlideAlongWall) {
+    // Wall along X at z=3
+    for (int x = -5; x <= 5; ++x) {
+        grid.set(x, 5, 3, 1.0f);
+        grid.set(x, 6, 3, 1.0f);
+    }
+
+    // Diagonal into wall: Z blocked, X passes
+    Vec3f pos(0.0f, 5.0f, 2.5f);
+    Vec3f disp(1.0f, 0.0f, 1.0f);
+
+    auto result = controller.move(pos, disp, grid);
+    EXPECT_TRUE(result.hitZ);
+    EXPECT_FALSE(result.hitX);
+    EXPECT_GT(result.resolvedPosition.x, 0.0f);
+    EXPECT_NEAR(result.resolvedPosition.z, 2.5f, 0.01f);
+}
+
+TEST_F(FlightControllerTest, HoverInPlace) {
+    Vec3f pos(0.0f, 5.0f, 0.0f);
+    Vec3f disp(0.0f, 0.0f, 0.0f);
+
+    auto result = controller.move(pos, disp, grid);
+    EXPECT_NEAR(result.resolvedPosition.x, 0.0f, 0.001f);
+    EXPECT_NEAR(result.resolvedPosition.y, 5.0f, 0.001f);
+    EXPECT_NEAR(result.resolvedPosition.z, 0.0f, 0.001f);
+}
+
+TEST_F(FlightControllerTest, DiagonalResolvedPerAxis) {
+    Vec3f pos(0.0f, 5.0f, 0.0f);
+    Vec3f disp(1.0f, 0.5f, -0.5f);
+
+    auto result = controller.move(pos, disp, grid);
+    EXPECT_NEAR(result.resolvedPosition.x, 1.0f, 0.01f);
+    EXPECT_NEAR(result.resolvedPosition.y, 5.5f, 0.01f);
+    EXPECT_NEAR(result.resolvedPosition.z, -0.5f, 0.01f);
+}
+
+TEST_F(FlightControllerTest, NegativeCoordinates) {
+    for (int x = -10; x <= -5; ++x)
+        for (int z = -10; z <= -5; ++z)
+            grid.set(x, -1, z, 1.0f);
+
+    Vec3f pos(-7.0f, 0.0f, -7.0f);
+    Vec3f disp(1.0f, 0.0f, 1.0f);
+
+    auto result = controller.move(pos, disp, grid);
+    EXPECT_NEAR(result.resolvedPosition.x, -6.0f, 0.01f);
+    EXPECT_NEAR(result.resolvedPosition.z, -6.0f, 0.01f);
+}
+
+TEST_F(FlightControllerTest, AABBCorrect) {
+    Vec3f pos(5.0f, 3.0f, 5.0f);
+    auto box = controller.getAABB(pos);
+
+    EXPECT_NEAR(box.min.x, 4.5f, 0.001f);
+    EXPECT_NEAR(box.min.y, 3.0f, 0.001f);
+    EXPECT_NEAR(box.min.z, 4.5f, 0.001f);
+    EXPECT_NEAR(box.max.x, 5.5f, 0.001f);
+    EXPECT_NEAR(box.max.y, 5.0f, 0.001f);
+    EXPECT_NEAR(box.max.z, 5.5f, 0.001f);
+}
+
+// Drag utility tests
+
+TEST_F(FlightControllerTest, DragReducesVelocity) {
+    Vec3f vel(10.0f, 0.0f, 0.0f);
+    float drag = 5.0f;
+    float dt = 1.0f / 60.0f;
+
+    Vec3f result = FlightController::applyDrag(vel, drag, dt);
+    float speed = std::sqrt(result.x * result.x + result.y * result.y + result.z * result.z);
+    EXPECT_LT(speed, 10.0f);
+    EXPECT_GT(speed, 0.0f);
+}
+
+TEST_F(FlightControllerTest, DragClampsNearZero) {
+    Vec3f vel(0.005f, 0.0f, 0.0f);
+    float drag = 5.0f;
+    float dt = 1.0f / 60.0f;
+
+    Vec3f result = FlightController::applyDrag(vel, drag, dt);
+    EXPECT_NEAR(result.x, 0.0f, 0.001f);
+    EXPECT_NEAR(result.y, 0.0f, 0.001f);
+    EXPECT_NEAR(result.z, 0.0f, 0.001f);
+}
+
+TEST_F(FlightControllerTest, DragZeroCoeffPreservesVelocity) {
+    Vec3f vel(10.0f, 5.0f, -3.0f);
+
+    Vec3f result = FlightController::applyDrag(vel, 0.0f, 1.0f / 60.0f);
+    EXPECT_NEAR(result.x, 10.0f, 0.001f);
+    EXPECT_NEAR(result.y, 5.0f, 0.001f);
+    EXPECT_NEAR(result.z, -3.0f, 0.001f);
+}
+
+TEST_F(FlightControllerTest, DragLargeDtClampsToZero) {
+    Vec3f vel(10.0f, 5.0f, 0.0f);
+    // drag * dt > 1.0 should clamp factor to 0
+    Vec3f result = FlightController::applyDrag(vel, 10.0f, 1.0f);
+    EXPECT_NEAR(result.x, 0.0f, 0.001f);
+    EXPECT_NEAR(result.y, 0.0f, 0.001f);
+}

--- a/tests/unit/core/InputRouterTest.cc
+++ b/tests/unit/core/InputRouterTest.cc
@@ -1,0 +1,319 @@
+#include "fabric/core/InputRouter.hh"
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+using namespace fabric;
+
+class InputRouterTest : public ::testing::Test {
+  protected:
+    EventDispatcher dispatcher;
+    InputManager inputMgr{dispatcher};
+    InputRouter router{inputMgr};
+
+    static SDL_Event makeKeyDown(SDL_Keycode key, SDL_Keymod mod = SDL_KMOD_NONE,
+                                 bool repeat = false) {
+        SDL_Event e = {};
+        e.type = SDL_EVENT_KEY_DOWN;
+        e.key.key = key;
+        e.key.mod = mod;
+        e.key.down = true;
+        e.key.repeat = repeat;
+        return e;
+    }
+
+    static SDL_Event makeKeyUp(SDL_Keycode key, SDL_Keymod mod = SDL_KMOD_NONE) {
+        SDL_Event e = {};
+        e.type = SDL_EVENT_KEY_UP;
+        e.key.key = key;
+        e.key.mod = mod;
+        e.key.down = false;
+        e.key.repeat = false;
+        return e;
+    }
+
+    static SDL_Event makeMouseMotion(float x, float y, float xrel, float yrel) {
+        SDL_Event e = {};
+        e.type = SDL_EVENT_MOUSE_MOTION;
+        e.motion.x = x;
+        e.motion.y = y;
+        e.motion.xrel = xrel;
+        e.motion.yrel = yrel;
+        return e;
+    }
+
+    static SDL_Event makeMouseButton(Uint8 button, bool down) {
+        SDL_Event e = {};
+        e.type = down ? SDL_EVENT_MOUSE_BUTTON_DOWN : SDL_EVENT_MOUSE_BUTTON_UP;
+        e.button.button = button;
+        e.button.down = down;
+        return e;
+    }
+
+    static SDL_Event makeMouseWheel(float y) {
+        SDL_Event e = {};
+        e.type = SDL_EVENT_MOUSE_WHEEL;
+        e.wheel.y = y;
+        return e;
+    }
+
+    // Cannot construct real SDL_EVENT_TEXT_INPUT (text is const char* managed by SDL),
+    // so text input forwarding is tested at integration level.
+};
+
+// -- Default mode --
+
+TEST_F(InputRouterTest, DefaultModeIsGameOnly) {
+    EXPECT_EQ(router.mode(), InputMode::GameOnly);
+}
+
+// -- Mode setting --
+
+TEST_F(InputRouterTest, SetModeChangesMode) {
+    router.setMode(InputMode::UIOnly);
+    EXPECT_EQ(router.mode(), InputMode::UIOnly);
+
+    router.setMode(InputMode::GameAndUI);
+    EXPECT_EQ(router.mode(), InputMode::GameAndUI);
+
+    router.setMode(InputMode::GameOnly);
+    EXPECT_EQ(router.mode(), InputMode::GameOnly);
+}
+
+// -- Escape toggle --
+
+TEST_F(InputRouterTest, EscapeTogglesGameOnlyToUIOnly) {
+    EXPECT_EQ(router.mode(), InputMode::GameOnly);
+
+    auto esc = makeKeyDown(SDLK_ESCAPE);
+    EXPECT_TRUE(router.routeEvent(esc, nullptr));
+    EXPECT_EQ(router.mode(), InputMode::UIOnly);
+}
+
+TEST_F(InputRouterTest, EscapeTogglesUIOnlyToGameOnly) {
+    router.setMode(InputMode::UIOnly);
+
+    auto esc = makeKeyDown(SDLK_ESCAPE);
+    EXPECT_TRUE(router.routeEvent(esc, nullptr));
+    EXPECT_EQ(router.mode(), InputMode::GameOnly);
+}
+
+TEST_F(InputRouterTest, EscapeDoesNotToggleGameAndUI) {
+    router.setMode(InputMode::GameAndUI);
+
+    auto esc = makeKeyDown(SDLK_ESCAPE);
+    router.routeEvent(esc, nullptr);
+    // GameAndUI stays as-is (toggle only affects GameOnly<->UIOnly)
+    EXPECT_EQ(router.mode(), InputMode::GameAndUI);
+}
+
+TEST_F(InputRouterTest, EscapeRepeatIsIgnoredForToggle) {
+    auto escRepeat = makeKeyDown(SDLK_ESCAPE, SDL_KMOD_NONE, true);
+    // Repeats should not toggle. They fall through to normal routing.
+    router.routeEvent(escRepeat, nullptr);
+    EXPECT_EQ(router.mode(), InputMode::GameOnly);
+}
+
+// -- GameOnly routing (null context) --
+
+TEST_F(InputRouterTest, GameOnlyForwardsToInputManager) {
+    inputMgr.bindKey("forward", SDLK_W);
+
+    auto e = makeKeyDown(SDLK_W);
+    EXPECT_TRUE(router.routeEvent(e, nullptr));
+    EXPECT_TRUE(inputMgr.isActionActive("forward"));
+}
+
+TEST_F(InputRouterTest, GameOnlyForwardsMouseMotion) {
+    auto e = makeMouseMotion(100.0f, 200.0f, 5.0f, -3.0f);
+    EXPECT_TRUE(router.routeEvent(e, nullptr));
+
+    EXPECT_FLOAT_EQ(inputMgr.mouseX(), 100.0f);
+    EXPECT_FLOAT_EQ(inputMgr.mouseY(), 200.0f);
+}
+
+TEST_F(InputRouterTest, GameOnlyForwardsMouseButton) {
+    auto e = makeMouseButton(1, true);
+    EXPECT_TRUE(router.routeEvent(e, nullptr));
+    EXPECT_TRUE(inputMgr.mouseButton(1));
+}
+
+// -- UIOnly with null context --
+
+TEST_F(InputRouterTest, UIOnlyWithNullContextReturnsFalse) {
+    router.setMode(InputMode::UIOnly);
+    inputMgr.bindKey("forward", SDLK_W);
+
+    auto e = makeKeyDown(SDLK_W);
+    EXPECT_FALSE(router.routeEvent(e, nullptr));
+    // InputManager should NOT receive the event
+    EXPECT_FALSE(inputMgr.isActionActive("forward"));
+}
+
+// -- GameAndUI with null context falls back to game --
+
+TEST_F(InputRouterTest, GameAndUIWithNullContextForwardsToGame) {
+    router.setMode(InputMode::GameAndUI);
+    inputMgr.bindKey("forward", SDLK_W);
+
+    auto e = makeKeyDown(SDLK_W);
+    EXPECT_TRUE(router.routeEvent(e, nullptr));
+    EXPECT_TRUE(inputMgr.isActionActive("forward"));
+}
+
+// -- beginFrame delegates --
+
+TEST_F(InputRouterTest, BeginFrameResetsInputManager) {
+    auto motion = makeMouseMotion(50.0f, 50.0f, 10.0f, 20.0f);
+    router.routeEvent(motion, nullptr);
+
+    EXPECT_FLOAT_EQ(inputMgr.mouseDeltaX(), 10.0f);
+    router.beginFrame();
+    EXPECT_FLOAT_EQ(inputMgr.mouseDeltaX(), 0.0f);
+}
+
+// -- toggleUIMode --
+
+TEST_F(InputRouterTest, ToggleFromGameOnly) {
+    router.toggleUIMode();
+    EXPECT_EQ(router.mode(), InputMode::UIOnly);
+}
+
+TEST_F(InputRouterTest, ToggleFromUIOnly) {
+    router.setMode(InputMode::UIOnly);
+    router.toggleUIMode();
+    EXPECT_EQ(router.mode(), InputMode::GameOnly);
+}
+
+TEST_F(InputRouterTest, ToggleFromGameAndUIDoesNothing) {
+    router.setMode(InputMode::GameAndUI);
+    router.toggleUIMode();
+    EXPECT_EQ(router.mode(), InputMode::GameAndUI);
+}
+
+// -- SDL key to RmlUI key mapping --
+
+TEST_F(InputRouterTest, KeyMapLetters) {
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_A), Rml::Input::KI_A);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_Z), Rml::Input::KI_Z);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_M), Rml::Input::KI_M);
+}
+
+TEST_F(InputRouterTest, KeyMapDigits) {
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_0), Rml::Input::KI_0);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_9), Rml::Input::KI_9);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_5), Rml::Input::KI_5);
+}
+
+TEST_F(InputRouterTest, KeyMapFunctionKeys) {
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_F1), Rml::Input::KI_F1);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_F12), Rml::Input::KI_F12);
+}
+
+TEST_F(InputRouterTest, KeyMapSpecialKeys) {
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_SPACE), Rml::Input::KI_SPACE);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_RETURN), Rml::Input::KI_RETURN);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_ESCAPE), Rml::Input::KI_ESCAPE);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_BACKSPACE), Rml::Input::KI_BACK);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_TAB), Rml::Input::KI_TAB);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_DELETE), Rml::Input::KI_DELETE);
+}
+
+TEST_F(InputRouterTest, KeyMapArrows) {
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_LEFT), Rml::Input::KI_LEFT);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_RIGHT), Rml::Input::KI_RIGHT);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_UP), Rml::Input::KI_UP);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_DOWN), Rml::Input::KI_DOWN);
+}
+
+TEST_F(InputRouterTest, KeyMapNavigation) {
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_HOME), Rml::Input::KI_HOME);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_END), Rml::Input::KI_END);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_PAGEUP), Rml::Input::KI_PRIOR);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_PAGEDOWN), Rml::Input::KI_NEXT);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_INSERT), Rml::Input::KI_INSERT);
+}
+
+TEST_F(InputRouterTest, KeyMapModifierKeys) {
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_LSHIFT), Rml::Input::KI_LSHIFT);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_RSHIFT), Rml::Input::KI_RSHIFT);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_LCTRL), Rml::Input::KI_LCONTROL);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_RCTRL), Rml::Input::KI_RCONTROL);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_LALT), Rml::Input::KI_LMENU);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_RALT), Rml::Input::KI_RMENU);
+}
+
+TEST_F(InputRouterTest, KeyMapNumpad) {
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_KP_0), Rml::Input::KI_NUMPAD0);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_KP_9), Rml::Input::KI_NUMPAD9);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_KP_ENTER), Rml::Input::KI_NUMPADENTER);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_KP_MULTIPLY), Rml::Input::KI_MULTIPLY);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_KP_PLUS), Rml::Input::KI_ADD);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_KP_MINUS), Rml::Input::KI_SUBTRACT);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_KP_PERIOD), Rml::Input::KI_DECIMAL);
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_KP_DIVIDE), Rml::Input::KI_DIVIDE);
+}
+
+TEST_F(InputRouterTest, KeyMapUnknownReturnsUnknown) {
+    // An unmapped key should return KI_UNKNOWN
+    EXPECT_EQ(InputRouter::sdlKeyToRmlKey(SDLK_UNKNOWN), Rml::Input::KI_UNKNOWN);
+}
+
+// -- SDL modifier to RmlUI modifier mapping --
+
+TEST_F(InputRouterTest, ModMapShift) {
+    int rmlMod = InputRouter::sdlModToRmlMod(SDL_KMOD_LSHIFT);
+    EXPECT_TRUE(rmlMod & Rml::Input::KM_SHIFT);
+    EXPECT_FALSE(rmlMod & Rml::Input::KM_CTRL);
+}
+
+TEST_F(InputRouterTest, ModMapCtrl) {
+    int rmlMod = InputRouter::sdlModToRmlMod(SDL_KMOD_LCTRL);
+    EXPECT_TRUE(rmlMod & Rml::Input::KM_CTRL);
+}
+
+TEST_F(InputRouterTest, ModMapAlt) {
+    int rmlMod = InputRouter::sdlModToRmlMod(SDL_KMOD_LALT);
+    EXPECT_TRUE(rmlMod & Rml::Input::KM_ALT);
+}
+
+TEST_F(InputRouterTest, ModMapMeta) {
+    int rmlMod = InputRouter::sdlModToRmlMod(SDL_KMOD_LGUI);
+    EXPECT_TRUE(rmlMod & Rml::Input::KM_META);
+}
+
+TEST_F(InputRouterTest, ModMapCombined) {
+    auto combined = static_cast<SDL_Keymod>(SDL_KMOD_LCTRL | SDL_KMOD_LSHIFT);
+    int rmlMod = InputRouter::sdlModToRmlMod(combined);
+    EXPECT_TRUE(rmlMod & Rml::Input::KM_CTRL);
+    EXPECT_TRUE(rmlMod & Rml::Input::KM_SHIFT);
+    EXPECT_FALSE(rmlMod & Rml::Input::KM_ALT);
+}
+
+TEST_F(InputRouterTest, ModMapNone) {
+    EXPECT_EQ(InputRouter::sdlModToRmlMod(SDL_KMOD_NONE), 0);
+}
+
+TEST_F(InputRouterTest, ModMapCapsLock) {
+    int rmlMod = InputRouter::sdlModToRmlMod(SDL_KMOD_CAPS);
+    EXPECT_TRUE(rmlMod & Rml::Input::KM_CAPSLOCK);
+}
+
+// -- Multiple events in sequence --
+
+TEST_F(InputRouterTest, ModeChangePreservesInputState) {
+    inputMgr.bindKey("forward", SDLK_W);
+
+    // Press W in GameOnly
+    auto down = makeKeyDown(SDLK_W);
+    router.routeEvent(down, nullptr);
+    EXPECT_TRUE(inputMgr.isActionActive("forward"));
+
+    // Switch to UIOnly (via Escape)
+    auto esc = makeKeyDown(SDLK_ESCAPE);
+    router.routeEvent(esc, nullptr);
+    EXPECT_EQ(router.mode(), InputMode::UIOnly);
+
+    // W is still "active" in InputManager (key wasn't released)
+    EXPECT_TRUE(inputMgr.isActionActive("forward"));
+}

--- a/tests/unit/core/MeleeSystemTest.cc
+++ b/tests/unit/core/MeleeSystemTest.cc
@@ -1,0 +1,177 @@
+#include "fabric/core/MeleeSystem.hh"
+#include <gtest/gtest.h>
+
+using namespace fabric;
+
+class MeleeSystemTest : public ::testing::Test {
+  protected:
+    EventDispatcher dispatcher;
+};
+
+TEST_F(MeleeSystemTest, AttackHitboxPositionedInFrontPosZ) {
+    MeleeSystem ms(dispatcher);
+    MeleeConfig config;
+    config.reach = 4.0f;
+    config.width = 2.0f;
+    config.height = 2.0f;
+
+    Vec3f pos(0.0f, 0.0f, 0.0f);
+    Vec3f facing(0.0f, 0.0f, 1.0f);
+    auto attack = ms.createAttack(pos, facing, config);
+
+    // Center should be at (0, 0, 2) = pos + facing * reach/2
+    auto center = attack.hitbox.center();
+    EXPECT_NEAR(center.x, 0.0f, 0.01f);
+    EXPECT_NEAR(center.y, 0.0f, 0.01f);
+    EXPECT_NEAR(center.z, 2.0f, 0.01f);
+
+    // Extents: (width/2, height/2, reach/2) = (1, 1, 2)
+    EXPECT_NEAR(attack.hitbox.min.x, -1.0f, 0.01f);
+    EXPECT_NEAR(attack.hitbox.max.x, 1.0f, 0.01f);
+    EXPECT_NEAR(attack.hitbox.min.z, 0.0f, 0.01f);
+    EXPECT_NEAR(attack.hitbox.max.z, 4.0f, 0.01f);
+}
+
+TEST_F(MeleeSystemTest, AttackHitboxFacingNegX) {
+    MeleeSystem ms(dispatcher);
+    MeleeConfig config;
+    config.reach = 3.0f;
+
+    Vec3f pos(10.0f, 5.0f, 10.0f);
+    Vec3f facing(-1.0f, 0.0f, 0.0f);
+    auto attack = ms.createAttack(pos, facing, config);
+
+    auto center = attack.hitbox.center();
+    EXPECT_NEAR(center.x, 8.5f, 0.01f); // 10 - 1.5
+    EXPECT_NEAR(center.y, 5.0f, 0.01f);
+    EXPECT_NEAR(center.z, 10.0f, 0.01f);
+}
+
+TEST_F(MeleeSystemTest, AttackHitboxFacingPosY) {
+    MeleeSystem ms(dispatcher);
+    MeleeConfig config;
+    config.reach = 3.0f;
+    config.width = 2.0f;
+
+    Vec3f pos(0.0f, 0.0f, 0.0f);
+    Vec3f facing(0.0f, 1.0f, 0.0f);
+    auto attack = ms.createAttack(pos, facing, config);
+
+    auto center = attack.hitbox.center();
+    EXPECT_NEAR(center.y, 1.5f, 0.01f);
+    // Y-dominant: halfExtents = (width/2, reach/2, width/2)
+    EXPECT_NEAR(attack.hitbox.min.x, -1.0f, 0.01f);
+    EXPECT_NEAR(attack.hitbox.max.x, 1.0f, 0.01f);
+}
+
+TEST_F(MeleeSystemTest, HitDetectionTargetInside) {
+    MeleeSystem ms(dispatcher);
+    MeleeConfig config;
+    config.reach = 4.0f;
+    config.width = 2.0f;
+    config.height = 2.0f;
+
+    auto attack = ms.createAttack(Vec3f(0, 0, 0), Vec3f(0, 0, 1), config);
+
+    std::vector<AABB> targets = {
+        AABB(Vec3f(-0.5f, -0.5f, 1.5f), Vec3f(0.5f, 0.5f, 2.5f))
+    };
+
+    auto hits = ms.checkHits(attack, targets);
+    ASSERT_EQ(hits.size(), 1u);
+    EXPECT_EQ(hits[0], 0u);
+}
+
+TEST_F(MeleeSystemTest, MissDetectionTargetOutside) {
+    MeleeSystem ms(dispatcher);
+    MeleeConfig config;
+    config.reach = 4.0f;
+    config.width = 2.0f;
+    config.height = 2.0f;
+
+    auto attack = ms.createAttack(Vec3f(0, 0, 0), Vec3f(0, 0, 1), config);
+
+    std::vector<AABB> targets = {
+        AABB(Vec3f(10.0f, 10.0f, 10.0f), Vec3f(11.0f, 11.0f, 11.0f))
+    };
+
+    auto hits = ms.checkHits(attack, targets);
+    EXPECT_TRUE(hits.empty());
+}
+
+TEST_F(MeleeSystemTest, MultipleTargetsHitsAll) {
+    MeleeSystem ms(dispatcher);
+    MeleeConfig config;
+    config.reach = 4.0f;
+    config.width = 2.0f;
+    config.height = 2.0f;
+
+    auto attack = ms.createAttack(Vec3f(0, 0, 0), Vec3f(0, 0, 1), config);
+
+    std::vector<AABB> targets = {
+        AABB(Vec3f(-0.5f, -0.5f, 1.0f), Vec3f(0.5f, 0.5f, 2.0f)),
+        AABB(Vec3f(-0.5f, -0.5f, 3.0f), Vec3f(0.5f, 0.5f, 3.5f)),
+        AABB(Vec3f(20.0f, 20.0f, 20.0f), Vec3f(21.0f, 21.0f, 21.0f))
+    };
+
+    auto hits = ms.checkHits(attack, targets);
+    ASSERT_EQ(hits.size(), 2u);
+    EXPECT_EQ(hits[0], 0u);
+    EXPECT_EQ(hits[1], 1u);
+}
+
+TEST_F(MeleeSystemTest, CooldownBlocksAttack) {
+    MeleeSystem ms(dispatcher);
+    EXPECT_FALSE(ms.canAttack(0.5f));
+    EXPECT_TRUE(ms.canAttack(0.0f));
+    EXPECT_TRUE(ms.canAttack(-0.1f));
+}
+
+TEST_F(MeleeSystemTest, CooldownUpdateDecrementsCorrectly) {
+    MeleeSystem ms(dispatcher);
+    float remaining = ms.updateCooldown(0.5f, 0.2f);
+    EXPECT_NEAR(remaining, 0.3f, 0.001f);
+}
+
+TEST_F(MeleeSystemTest, CooldownUpdateClampsToZero) {
+    MeleeSystem ms(dispatcher);
+    float remaining = ms.updateCooldown(0.1f, 0.5f);
+    EXPECT_FLOAT_EQ(remaining, 0.0f);
+}
+
+TEST_F(MeleeSystemTest, DamageEventDispatched) {
+    MeleeSystem ms(dispatcher);
+    float receivedDamage = 0.0f;
+    dispatcher.addEventListener("melee_damage", [&](Event& e) {
+        receivedDamage = e.getData<float>("damage");
+    });
+
+    ms.emitDamageEvent(Vec3f(1, 2, 3), 25.0f, Vec3f(0, 0, 1));
+    EXPECT_FLOAT_EQ(receivedDamage, 25.0f);
+}
+
+TEST_F(MeleeSystemTest, AttackDirectionNormalized) {
+    MeleeSystem ms(dispatcher);
+    MeleeConfig config;
+    Vec3f facing(3.0f, 0.0f, 4.0f); // length = 5
+    auto attack = ms.createAttack(Vec3f(0, 0, 0), facing, config);
+
+    float len = std::sqrt(
+        attack.direction.x * attack.direction.x +
+        attack.direction.y * attack.direction.y +
+        attack.direction.z * attack.direction.z);
+    EXPECT_NEAR(len, 1.0f, 0.001f);
+    EXPECT_NEAR(attack.direction.x, 0.6f, 0.001f);
+    EXPECT_NEAR(attack.direction.z, 0.8f, 0.001f);
+}
+
+TEST_F(MeleeSystemTest, AttackCarriesConfigValues) {
+    MeleeSystem ms(dispatcher);
+    MeleeConfig config;
+    config.damage = 42.0f;
+    config.knockback = 7.5f;
+
+    auto attack = ms.createAttack(Vec3f(0, 0, 0), Vec3f(0, 0, 1), config);
+    EXPECT_FLOAT_EQ(attack.damage, 42.0f);
+    EXPECT_FLOAT_EQ(attack.knockback, 7.5f);
+}

--- a/tests/unit/core/MovementFSMTest.cc
+++ b/tests/unit/core/MovementFSMTest.cc
@@ -1,0 +1,138 @@
+#include <gtest/gtest.h>
+#include "fabric/core/MovementFSM.hh"
+
+using namespace fabric;
+
+class MovementFSMTest : public ::testing::Test {
+  protected:
+    MovementFSM fsm;
+};
+
+TEST_F(MovementFSMTest, DefaultStateIsGrounded) {
+    EXPECT_EQ(fsm.currentState(), CharacterState::Grounded);
+}
+
+TEST_F(MovementFSMTest, GroundedToJumping) {
+    EXPECT_TRUE(fsm.tryTransition(CharacterState::Jumping));
+    EXPECT_EQ(fsm.currentState(), CharacterState::Jumping);
+}
+
+TEST_F(MovementFSMTest, JumpingToFalling) {
+    fsm.tryTransition(CharacterState::Jumping);
+    EXPECT_TRUE(fsm.tryTransition(CharacterState::Falling));
+    EXPECT_EQ(fsm.currentState(), CharacterState::Falling);
+}
+
+TEST_F(MovementFSMTest, FallingToGrounded) {
+    fsm.tryTransition(CharacterState::Jumping);
+    fsm.tryTransition(CharacterState::Falling);
+    EXPECT_TRUE(fsm.tryTransition(CharacterState::Grounded));
+    EXPECT_EQ(fsm.currentState(), CharacterState::Grounded);
+}
+
+TEST_F(MovementFSMTest, GroundedToFlying) {
+    EXPECT_TRUE(fsm.tryTransition(CharacterState::Flying));
+    EXPECT_EQ(fsm.currentState(), CharacterState::Flying);
+}
+
+TEST_F(MovementFSMTest, FlyingToFalling) {
+    fsm.tryTransition(CharacterState::Flying);
+    EXPECT_TRUE(fsm.tryTransition(CharacterState::Falling));
+    EXPECT_EQ(fsm.currentState(), CharacterState::Falling);
+}
+
+TEST_F(MovementFSMTest, GroundedToDashing) {
+    EXPECT_TRUE(fsm.tryTransition(CharacterState::Dashing));
+    EXPECT_EQ(fsm.currentState(), CharacterState::Dashing);
+}
+
+TEST_F(MovementFSMTest, FlyingToBoosting) {
+    fsm.tryTransition(CharacterState::Flying);
+    EXPECT_TRUE(fsm.tryTransition(CharacterState::Boosting));
+    EXPECT_EQ(fsm.currentState(), CharacterState::Boosting);
+}
+
+TEST_F(MovementFSMTest, InvalidTransitionGroundedToRagdoll) {
+    EXPECT_FALSE(fsm.tryTransition(CharacterState::Ragdoll));
+    EXPECT_EQ(fsm.currentState(), CharacterState::Grounded);
+}
+
+TEST_F(MovementFSMTest, InvalidTransitionDashingToSwimming) {
+    fsm.tryTransition(CharacterState::Dashing);
+    EXPECT_FALSE(fsm.tryTransition(CharacterState::Swimming));
+    EXPECT_EQ(fsm.currentState(), CharacterState::Dashing);
+}
+
+TEST_F(MovementFSMTest, StateQueriesGrounded) {
+    EXPECT_TRUE(fsm.isGrounded());
+    EXPECT_FALSE(fsm.isAirborne());
+    EXPECT_FALSE(fsm.isFlying());
+    EXPECT_TRUE(fsm.canDash());
+}
+
+TEST_F(MovementFSMTest, StateQueriesJumping) {
+    fsm.tryTransition(CharacterState::Jumping);
+    EXPECT_FALSE(fsm.isGrounded());
+    EXPECT_TRUE(fsm.isAirborne());
+    EXPECT_FALSE(fsm.isFlying());
+    EXPECT_FALSE(fsm.canDash());
+}
+
+TEST_F(MovementFSMTest, StateQueriesFalling) {
+    fsm.tryTransition(CharacterState::Falling);
+    EXPECT_FALSE(fsm.isGrounded());
+    EXPECT_TRUE(fsm.isAirborne());
+    EXPECT_FALSE(fsm.isFlying());
+    EXPECT_FALSE(fsm.canDash());
+}
+
+TEST_F(MovementFSMTest, StateQueriesFlying) {
+    fsm.tryTransition(CharacterState::Flying);
+    EXPECT_FALSE(fsm.isGrounded());
+    EXPECT_FALSE(fsm.isAirborne());
+    EXPECT_TRUE(fsm.isFlying());
+    EXPECT_FALSE(fsm.canDash());
+}
+
+TEST_F(MovementFSMTest, StateQueriesBoosting) {
+    fsm.tryTransition(CharacterState::Flying);
+    fsm.tryTransition(CharacterState::Boosting);
+    EXPECT_FALSE(fsm.isGrounded());
+    EXPECT_FALSE(fsm.isAirborne());
+    EXPECT_TRUE(fsm.isFlying());
+    EXPECT_FALSE(fsm.canDash());
+}
+
+TEST_F(MovementFSMTest, FullJumpCycle) {
+    EXPECT_TRUE(fsm.tryTransition(CharacterState::Jumping));
+    EXPECT_TRUE(fsm.tryTransition(CharacterState::Falling));
+    EXPECT_TRUE(fsm.tryTransition(CharacterState::Grounded));
+    EXPECT_TRUE(fsm.isGrounded());
+}
+
+TEST_F(MovementFSMTest, BoostingReturnToFlying) {
+    fsm.tryTransition(CharacterState::Flying);
+    fsm.tryTransition(CharacterState::Boosting);
+    EXPECT_TRUE(fsm.tryTransition(CharacterState::Flying));
+    EXPECT_EQ(fsm.currentState(), CharacterState::Flying);
+}
+
+TEST_F(MovementFSMTest, SelfTransitionIsNoop) {
+    EXPECT_TRUE(fsm.tryTransition(CharacterState::Grounded));
+    EXPECT_EQ(fsm.currentState(), CharacterState::Grounded);
+}
+
+TEST_F(MovementFSMTest, StateToStringCoversAllStates) {
+    EXPECT_EQ(MovementFSM::stateToString(CharacterState::Grounded), "Grounded");
+    EXPECT_EQ(MovementFSM::stateToString(CharacterState::Falling), "Falling");
+    EXPECT_EQ(MovementFSM::stateToString(CharacterState::Jumping), "Jumping");
+    EXPECT_EQ(MovementFSM::stateToString(CharacterState::Climbing), "Climbing");
+    EXPECT_EQ(MovementFSM::stateToString(CharacterState::Swimming), "Swimming");
+    EXPECT_EQ(MovementFSM::stateToString(CharacterState::WallRunning), "WallRunning");
+    EXPECT_EQ(MovementFSM::stateToString(CharacterState::Hanging), "Hanging");
+    EXPECT_EQ(MovementFSM::stateToString(CharacterState::Flying), "Flying");
+    EXPECT_EQ(MovementFSM::stateToString(CharacterState::Sliding), "Sliding");
+    EXPECT_EQ(MovementFSM::stateToString(CharacterState::Ragdoll), "Ragdoll");
+    EXPECT_EQ(MovementFSM::stateToString(CharacterState::Dashing), "Dashing");
+    EXPECT_EQ(MovementFSM::stateToString(CharacterState::Boosting), "Boosting");
+}

--- a/tests/unit/core/TransitionControllerTest.cc
+++ b/tests/unit/core/TransitionControllerTest.cc
@@ -1,0 +1,125 @@
+#include <gtest/gtest.h>
+#include "fabric/core/TransitionController.hh"
+#include <cmath>
+
+using namespace fabric;
+
+class TransitionControllerTest : public ::testing::Test {
+  protected:
+    TransitionController tc;
+    ChunkedGrid<float> grid;
+
+    void fillFloor(int y, int xMin, int xMax, int zMin, int zMax) {
+        for (int z = zMin; z <= zMax; ++z)
+            for (int x = xMin; x <= xMax; ++x)
+                grid.set(x, y, z, 1.0f);
+    }
+};
+
+// enterFlight tests
+
+TEST_F(TransitionControllerTest, EnterFlightPreservesMomentumScaled) {
+    Vec3f vel(10.0f, 0.0f, 5.0f);
+    auto result = tc.enterFlight(vel, 5.0f, 0.8f);
+
+    EXPECT_NEAR(result.velocity.x, 8.0f, 0.01f);
+    EXPECT_NEAR(result.velocity.z, 4.0f, 0.01f);
+}
+
+TEST_F(TransitionControllerTest, EnterFlightAddsUpwardImpulse) {
+    Vec3f vel(0.0f, 0.0f, 0.0f);
+    auto result = tc.enterFlight(vel, 7.5f);
+
+    EXPECT_NEAR(result.velocity.y, 7.5f, 0.01f);
+}
+
+TEST_F(TransitionControllerTest, EnterFlightReturnsFlyingState) {
+    Vec3f vel(3.0f, 1.0f, 2.0f);
+    auto result = tc.enterFlight(vel);
+
+    EXPECT_EQ(result.newState, CharacterState::Flying);
+}
+
+TEST_F(TransitionControllerTest, EnterFlightDefaultParams) {
+    Vec3f vel(10.0f, 0.0f, 10.0f);
+    auto result = tc.enterFlight(vel);
+
+    // Default: impulse=5.0, scale=0.8
+    EXPECT_NEAR(result.velocity.x, 8.0f, 0.01f);
+    EXPECT_NEAR(result.velocity.y, 5.0f, 0.01f);
+    EXPECT_NEAR(result.velocity.z, 8.0f, 0.01f);
+}
+
+TEST_F(TransitionControllerTest, EnterFlightZeroVelocity) {
+    Vec3f vel(0.0f, 0.0f, 0.0f);
+    auto result = tc.enterFlight(vel, 5.0f, 0.8f);
+
+    EXPECT_NEAR(result.velocity.x, 0.0f, 0.01f);
+    EXPECT_NEAR(result.velocity.y, 5.0f, 0.01f);
+    EXPECT_NEAR(result.velocity.z, 0.0f, 0.01f);
+}
+
+// exitFlight tests
+
+TEST_F(TransitionControllerTest, ExitFlightNearGroundGrounded) {
+    fillFloor(0, -5, 5, -5, 5);
+
+    Vec3f pos(0.0f, 1.5f, 0.0f);
+    Vec3f vel(5.0f, -2.0f, 3.0f);
+    auto result = tc.exitFlight(vel, pos, grid, 2.0f);
+
+    EXPECT_EQ(result.newState, CharacterState::Grounded);
+    EXPECT_NEAR(result.velocity.y, 0.0f, 0.01f);
+}
+
+TEST_F(TransitionControllerTest, ExitFlightPreservesHorizontalOnLand) {
+    fillFloor(0, -5, 5, -5, 5);
+
+    Vec3f pos(0.0f, 1.5f, 0.0f);
+    Vec3f vel(10.0f, -3.0f, 7.0f);
+    auto result = tc.exitFlight(vel, pos, grid, 2.0f);
+
+    EXPECT_NEAR(result.velocity.x, 10.0f, 0.01f);
+    EXPECT_NEAR(result.velocity.z, 7.0f, 0.01f);
+}
+
+TEST_F(TransitionControllerTest, ExitFlightInAirFalling) {
+    // No ground anywhere
+    Vec3f pos(0.0f, 50.0f, 0.0f);
+    Vec3f vel(5.0f, 0.0f, 0.0f);
+    auto result = tc.exitFlight(vel, pos, grid, 2.0f);
+
+    EXPECT_EQ(result.newState, CharacterState::Falling);
+}
+
+TEST_F(TransitionControllerTest, ExitFlightFallingPreservesVelocity) {
+    Vec3f pos(0.0f, 50.0f, 0.0f);
+    Vec3f vel(5.0f, -3.0f, 2.0f);
+    auto result = tc.exitFlight(vel, pos, grid, 2.0f);
+
+    EXPECT_NEAR(result.velocity.x, 5.0f, 0.01f);
+    EXPECT_NEAR(result.velocity.y, -3.0f, 0.01f);
+    EXPECT_NEAR(result.velocity.z, 2.0f, 0.01f);
+}
+
+TEST_F(TransitionControllerTest, ExitFlightGroundJustBeyondRange) {
+    fillFloor(0, -5, 5, -5, 5);
+
+    // Position at y=3.5, groundCheckDistance=2.0: scans y=2 down to y=1, misses floor at y=0
+    Vec3f pos(0.0f, 3.5f, 0.0f);
+    Vec3f vel(0.0f, 0.0f, 0.0f);
+    auto result = tc.exitFlight(vel, pos, grid, 2.0f);
+
+    EXPECT_EQ(result.newState, CharacterState::Falling);
+}
+
+TEST_F(TransitionControllerTest, ExitFlightLargerCheckDistance) {
+    fillFloor(0, -5, 5, -5, 5);
+
+    // Same position but larger check distance finds the floor
+    Vec3f pos(0.0f, 3.5f, 0.0f);
+    Vec3f vel(0.0f, 0.0f, 0.0f);
+    auto result = tc.exitFlight(vel, pos, grid, 5.0f);
+
+    EXPECT_EQ(result.newState, CharacterState::Grounded);
+}

--- a/tests/unit/core/VoxelInteractionTest.cc
+++ b/tests/unit/core/VoxelInteractionTest.cc
@@ -1,0 +1,167 @@
+#include "fabric/core/VoxelInteraction.hh"
+#include "fabric/core/ChunkMeshManager.hh"
+#include <gtest/gtest.h>
+
+using namespace fabric;
+
+class VoxelInteractionTest : public ::testing::Test {
+  protected:
+    DensityField density;
+    EssenceField essence;
+    EventDispatcher dispatcher;
+
+    void SetUp() override {
+        eventCount = 0;
+        dispatcher.addEventListener(kVoxelChangedEvent, [this](Event&) { ++eventCount; });
+    }
+
+    int eventCount = 0;
+};
+
+TEST_F(VoxelInteractionTest, CreateMatterPlacesAdjacentPosZ) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    VoxelHit hit{5, 5, 5, 0, 0, 1, 1.0f}; // normal +Z
+    auto result = vi.createMatter(hit);
+    EXPECT_TRUE(result.success);
+    EXPECT_EQ(result.x, 5);
+    EXPECT_EQ(result.y, 5);
+    EXPECT_EQ(result.z, 6);
+    EXPECT_FLOAT_EQ(density.read(5, 5, 6), 1.0f);
+}
+
+TEST_F(VoxelInteractionTest, CreateMatterPlacesAdjacentNegZ) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    VoxelHit hit{5, 5, 5, 0, 0, -1, 1.0f};
+    auto result = vi.createMatter(hit);
+    EXPECT_TRUE(result.success);
+    EXPECT_EQ(result.z, 4);
+    EXPECT_FLOAT_EQ(density.read(5, 5, 4), 1.0f);
+}
+
+TEST_F(VoxelInteractionTest, CreateMatterPlacesAdjacentPosX) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    VoxelHit hit{5, 5, 5, 1, 0, 0, 1.0f};
+    auto result = vi.createMatter(hit);
+    EXPECT_EQ(result.x, 6);
+    EXPECT_FLOAT_EQ(density.read(6, 5, 5), 1.0f);
+}
+
+TEST_F(VoxelInteractionTest, CreateMatterPlacesAdjacentNegX) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    VoxelHit hit{5, 5, 5, -1, 0, 0, 1.0f};
+    auto result = vi.createMatter(hit);
+    EXPECT_EQ(result.x, 4);
+}
+
+TEST_F(VoxelInteractionTest, CreateMatterPlacesAdjacentPosY) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    VoxelHit hit{5, 5, 5, 0, 1, 0, 1.0f};
+    auto result = vi.createMatter(hit);
+    EXPECT_EQ(result.y, 6);
+}
+
+TEST_F(VoxelInteractionTest, CreateMatterPlacesAdjacentNegY) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    VoxelHit hit{5, 5, 5, 0, -1, 0, 1.0f};
+    auto result = vi.createMatter(hit);
+    EXPECT_EQ(result.y, 4);
+}
+
+TEST_F(VoxelInteractionTest, CreateMatterWritesEssence) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    Vector4<float, Space::World> color(1.0f, 0.0f, 0.0f, 1.0f);
+    VoxelHit hit{5, 5, 5, 0, 0, 1, 1.0f};
+    vi.createMatter(hit, 1.0f, color);
+    auto stored = essence.read(5, 5, 6);
+    EXPECT_FLOAT_EQ(stored.x, 1.0f);
+    EXPECT_FLOAT_EQ(stored.y, 0.0f);
+    EXPECT_FLOAT_EQ(stored.z, 0.0f);
+    EXPECT_FLOAT_EQ(stored.w, 1.0f);
+}
+
+TEST_F(VoxelInteractionTest, DestroyMatterSetsDensityToZero) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    density.write(5, 5, 5, 1.0f);
+    VoxelHit hit{5, 5, 5, 0, 0, -1, 1.0f};
+    auto result = vi.destroyMatter(hit);
+    EXPECT_TRUE(result.success);
+    EXPECT_EQ(result.x, 5);
+    EXPECT_FLOAT_EQ(density.read(5, 5, 5), 0.0f);
+}
+
+TEST_F(VoxelInteractionTest, CreateMatterEmitsVoxelChangedEvent) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    VoxelHit hit{5, 5, 5, 0, 0, 1, 1.0f};
+    vi.createMatter(hit);
+    EXPECT_EQ(eventCount, 1);
+}
+
+TEST_F(VoxelInteractionTest, DestroyMatterEmitsVoxelChangedEvent) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    density.write(5, 5, 5, 1.0f);
+    VoxelHit hit{5, 5, 5, 0, 0, -1, 1.0f};
+    vi.destroyMatter(hit);
+    EXPECT_EQ(eventCount, 1);
+}
+
+TEST_F(VoxelInteractionTest, CreateMatterAtWithRaycast) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    density.write(5, 5, 5, 1.0f);
+    auto result = vi.createMatterAt(density.grid(), 5.5f, 5.5f, 0.5f, 0.0f, 0.0f, 1.0f);
+    EXPECT_TRUE(result.success);
+    // Ray hits +Z face of voxel at (5,5,5), normal is (0,0,-1), so placement at (5,5,4)
+    EXPECT_EQ(result.z, 4);
+    EXPECT_FLOAT_EQ(density.read(5, 5, 4), 1.0f);
+}
+
+TEST_F(VoxelInteractionTest, DestroyMatterAtWithRaycast) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    density.write(5, 5, 5, 1.0f);
+    auto result = vi.destroyMatterAt(density.grid(), 5.5f, 5.5f, 0.5f, 0.0f, 0.0f, 1.0f);
+    EXPECT_TRUE(result.success);
+    EXPECT_FLOAT_EQ(density.read(5, 5, 5), 0.0f);
+}
+
+TEST_F(VoxelInteractionTest, CreateMatterAtNoHitReturnsFail) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    auto result = vi.createMatterAt(density.grid(), 0.5f, 0.5f, 0.5f, 1.0f, 0.0f, 0.0f);
+    EXPECT_FALSE(result.success);
+}
+
+TEST_F(VoxelInteractionTest, DestroyMatterAtNoHitReturnsFail) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    auto result = vi.destroyMatterAt(density.grid(), 0.5f, 0.5f, 0.5f, 1.0f, 0.0f, 0.0f);
+    EXPECT_FALSE(result.success);
+}
+
+TEST_F(VoxelInteractionTest, WouldOverlapDetectsIntersection) {
+    AABB player(Vec3f(4.5f, 4.5f, 4.5f), Vec3f(5.5f, 6.5f, 5.5f));
+    EXPECT_TRUE(VoxelInteraction::wouldOverlap(5, 5, 5, player));
+}
+
+TEST_F(VoxelInteractionTest, WouldOverlapNoIntersection) {
+    AABB player(Vec3f(0.0f, 0.0f, 0.0f), Vec3f(1.0f, 2.0f, 1.0f));
+    EXPECT_FALSE(VoxelInteraction::wouldOverlap(5, 5, 5, player));
+}
+
+TEST_F(VoxelInteractionTest, NegativeCoordinatesWork) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    density.write(-5, -3, -7, 1.0f);
+    VoxelHit hit{-5, -3, -7, 0, 0, -1, 1.0f};
+    auto result = vi.createMatter(hit);
+    EXPECT_TRUE(result.success);
+    EXPECT_EQ(result.x, -5);
+    EXPECT_EQ(result.y, -3);
+    EXPECT_EQ(result.z, -8);
+    EXPECT_FLOAT_EQ(density.read(-5, -3, -8), 1.0f);
+}
+
+TEST_F(VoxelInteractionTest, ChunkCoordsCalculatedCorrectly) {
+    VoxelInteraction vi(density, essence, dispatcher);
+    VoxelHit hit{31, 0, 0, 1, 0, 0, 1.0f}; // normal +X, target = (32, 0, 0)
+    auto result = vi.createMatter(hit);
+    EXPECT_EQ(result.x, 32);
+    EXPECT_EQ(result.cx, 1); // 32 >> 5 = 1
+    EXPECT_EQ(result.cy, 0);
+    EXPECT_EQ(result.cz, 0);
+}


### PR DESCRIPTION
## Summary

Sprint 5b adds the gameplay systems that make the voxel world interactive. Where 5a built the rendering and world infrastructure, 5b puts a player in it.

**12-state movement FSM** defines the full character state space: Grounded, Falling, Jumping, Climbing, Swimming, WallRunning, Hanging, Flying, Sliding, Ragdoll, Dashing, Boosting. Sprint 5b activates six of these with proper transition rules. The remaining six are registered but their transitions are deferred to later sprints. Built on the existing StateMachine template with thread-safe hooks and transition logging.

**AABB character controller** resolves collisions directly against ChunkedGrid density data. No intermediate collision mesh, no physics engine. Y-axis resolves first (gravity and jump), then X and Z independently. Step-up handles single-block ledges by checking headroom before raising the player. Ground detection probes downward with an epsilon offset. The controller queries voxel density at the threshold boundary, meaning the same grid serves rendering, physics, and gameplay without duplication.

**6DOF arcade flight controller** follows the same AABB sweep pattern but without gravity bias or step-up. All three axes resolve with equal priority. Velocity snaps instantly to input direction at base speed (ZoE-faithful arcade feel), then exponential drag bleeds speed when input stops. A configurable drift gravity adds subtle downward pull for feel tuning.

**Ground-air transitions** preserve horizontal momentum scaled by a configurable factor, with an upward impulse on liftoff. Exit-flight checks ground proximity via downward column scan through the density grid, routing to Grounded or Falling depending on surface distance. Dash and boost operate as short burst displacements with independent cooldowns for ground and air modes.

**Dual-mode camera controller** handles first-person (eye offset from player position) and third-person (orbit with configurable distance). Third-person uses DDA raycasting through ChunkedGrid for spring arm collision. When terrain occludes the desired camera position, the arm shortens smoothly via lerp. Pitch clamps to 89 degrees in ground mode but unlocks fully for flight.

**SDL3-to-RmlUI input forwarding** maps approximately 45 SDL keycodes to RmlUI key identifiers, plus modifier state and mouse button convention translation. InputMode routing splits input between game and UI across three modes: GameOnly sends everything to InputManager, UIOnly forwards to RmlUI, GameAndUI checks hover and focus state to decide per-event. Escape toggles between game and UI.

**VoxelInteraction** combines raycasting with field mutation. CREATE_MATTER places a voxel adjacent to the hit face using the surface normal as offset. DESTROY_MATTER zeroes density at the hit position. Both emit VoxelChanged events that feed into the dirty-chunk re-mesh pipeline from Sprint 5a. A static overlap check supports player push-out when placement would intersect the character AABB.

**MeleeSystem** generates axis-aligned attack hitboxes projected from the player position along the dominant facing direction. AABB intersection queries identify hit targets, with cooldown timers preventing spam. Damage events carry amount, knockback direction, and source/target positions.

147 new tests across 9 test files. 30 new source files (10 headers, 10 implementations, 10 test files).