### PR TITLE
feat: reverb zone BFS estimation (Sprint 11 Batch D)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ set(FABRIC_CORE_SOURCE_FILES
     src/core/PostProcess.cc
     src/core/DevConsole.cc
     src/core/ParticleSystem.cc
+    src/core/ReverbZone.cc
 )
 
 # Utils library components

--- a/include/fabric/core/ReverbZone.hh
+++ b/include/fabric/core/ReverbZone.hh
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "fabric/core/ChunkedGrid.hh"
+
+#include <algorithm>
+#include <cstdint>
+#include <deque>
+#include <unordered_set>
+
+namespace fabric {
+
+/// Result of BFS flood-fill zone estimation.
+struct ZoneEstimate {
+    int volume = 0;        ///< Number of air voxels visited.
+    int surfaceArea = 0;   ///< Number of solid-neighbor faces counted.
+    float openness = 0.0f; ///< Fraction of frontier voxels at budget limit (0=sealed, 1=open).
+    bool complete = true;  ///< True if BFS exhausted all reachable air within budget.
+};
+
+/// Reverb parameters derived from zone estimation.
+struct ReverbParams {
+    float decayTime = 0.0f; ///< RT60 in seconds, clamped to [0.1, 3.0].
+    float damping = 0.0f;   ///< Absorption factor [0.1, 0.9].
+    float wetMix = 0.0f;    ///< Wet/dry ratio [0.0, 1.0].
+};
+
+/// One-shot BFS flood-fill zone estimation.
+/// Walks 6-connected air voxels from start position, counting volume,
+/// surface area, and openness up to a budget cap.
+ZoneEstimate estimateZone(const ChunkedGrid<float>& density, int startX, int startY, int startZ, float threshold,
+                          int maxVoxels);
+
+/// Map a zone estimate to reverb parameters using the Sabine equation.
+ReverbParams mapToReverbParams(const ZoneEstimate& zone, float voxelSize = 1.0f);
+
+/// Incremental BFS zone estimator that can spread work across frames.
+class ReverbZoneEstimator {
+  public:
+    ReverbZoneEstimator() = default;
+
+    /// Reset BFS state and start from a new position.
+    void reset(int startX, int startY, int startZ);
+
+    /// Process up to `budget` voxels of BFS.
+    void advanceBFS(const ChunkedGrid<float>& density, float threshold, int budget);
+
+    /// Current zone estimate (may be partial if BFS is incomplete).
+    ZoneEstimate estimate() const;
+
+    /// True when BFS has no more frontier to explore.
+    bool isComplete() const;
+
+  private:
+    /// Pack 3 ints into a single 64-bit key for the visited set.
+    static int64_t packCoord(int x, int y, int z);
+
+    std::deque<std::array<int, 3>> queue_;
+    std::unordered_set<int64_t> visited_;
+
+    int volume_ = 0;
+    int surfaceArea_ = 0;
+    int frontierCount_ = 0; ///< Voxels remaining in queue when budget exhausted.
+    bool started_ = false;
+    bool complete_ = true;
+};
+
+} // namespace fabric

--- a/src/core/ReverbZone.cc
+++ b/src/core/ReverbZone.cc
@@ -1,0 +1,167 @@
+#include "fabric/core/ReverbZone.hh"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace fabric {
+
+// ---------- Coordinate packing ----------
+
+int64_t ReverbZoneEstimator::packCoord(int x, int y, int z) {
+    // Same packing scheme as ChunkedGrid::packKey but at voxel level.
+    return (static_cast<int64_t>(x) << 42) | (static_cast<int64_t>(y & 0x1FFFFF) << 21) |
+           static_cast<int64_t>(z & 0x1FFFFF);
+}
+
+// ---------- 6-connected neighbor offsets ----------
+
+static constexpr std::array<std::array<int, 3>, 6> kNeighborOffsets = {{
+    {{1, 0, 0}},
+    {{-1, 0, 0}},
+    {{0, 1, 0}},
+    {{0, -1, 0}},
+    {{0, 0, 1}},
+    {{0, 0, -1}},
+}};
+
+// ---------- One-shot estimateZone ----------
+
+ZoneEstimate estimateZone(const ChunkedGrid<float>& density, int startX, int startY, int startZ, float threshold,
+                          int maxVoxels) {
+    ReverbZoneEstimator estimator;
+    estimator.reset(startX, startY, startZ);
+    estimator.advanceBFS(density, threshold, maxVoxels);
+    return estimator.estimate();
+}
+
+// ---------- ReverbZoneEstimator ----------
+
+void ReverbZoneEstimator::reset(int startX, int startY, int startZ) {
+    queue_.clear();
+    visited_.clear();
+    volume_ = 0;
+    surfaceArea_ = 0;
+    frontierCount_ = 0;
+    started_ = true;
+    complete_ = false;
+
+    queue_.push_back({startX, startY, startZ});
+    visited_.insert(packCoord(startX, startY, startZ));
+}
+
+void ReverbZoneEstimator::advanceBFS(const ChunkedGrid<float>& density, float threshold, int budget) {
+    if (!started_ || complete_)
+        return;
+
+    int processed = 0;
+
+    while (!queue_.empty() && processed < budget) {
+        auto [x, y, z] = queue_.front();
+        queue_.pop_front();
+
+        float d = density.get(x, y, z);
+        if (d >= threshold) {
+            // This voxel is solid; skip it.
+            continue;
+        }
+
+        // Air voxel: count it.
+        ++volume_;
+        ++processed;
+
+        // Check 6-connected neighbors.
+        for (const auto& off : kNeighborOffsets) {
+            int nx = x + off[0];
+            int ny = y + off[1];
+            int nz = z + off[2];
+
+            float nd = density.get(nx, ny, nz);
+            if (nd >= threshold) {
+                // Solid neighbor: contributes to surface area.
+                ++surfaceArea_;
+            } else {
+                // Air neighbor: enqueue if not visited.
+                int64_t key = packCoord(nx, ny, nz);
+                if (visited_.find(key) == visited_.end()) {
+                    visited_.insert(key);
+                    queue_.push_back({nx, ny, nz});
+                }
+            }
+        }
+    }
+
+    if (queue_.empty()) {
+        complete_ = true;
+        frontierCount_ = 0;
+    } else {
+        complete_ = false;
+        frontierCount_ = static_cast<int>(queue_.size());
+    }
+}
+
+ZoneEstimate ReverbZoneEstimator::estimate() const {
+    ZoneEstimate est;
+    est.volume = volume_;
+    est.surfaceArea = surfaceArea_;
+    est.complete = complete_;
+
+    if (complete_ || volume_ == 0) {
+        // BFS completed or never started: no frontier remains.
+        // A fully sealed region finishes BFS with complete=true.
+        est.openness = 0.0f;
+    } else {
+        // BFS incomplete (budget-capped). Openness measures how unbounded the
+        // region is: 1 - (solid_faces / total_face_checks). In a fully open
+        // area surfaceArea=0 so openness=1.0. In a partially explored room
+        // with walls nearby, surfaceArea grows relative to volume.
+        float totalFaceChecks = 6.0f * static_cast<float>(std::max(volume_, 1));
+        est.openness = std::clamp(1.0f - static_cast<float>(surfaceArea_) / totalFaceChecks, 0.0f, 1.0f);
+    }
+
+    return est;
+}
+
+bool ReverbZoneEstimator::isComplete() const {
+    return !started_ || complete_;
+}
+
+// ---------- mapToReverbParams ----------
+
+ReverbParams mapToReverbParams(const ZoneEstimate& zone, float voxelSize) {
+    ReverbParams params;
+
+    if (zone.volume <= 0) {
+        params.decayTime = 0.1f;
+        params.damping = 0.9f;
+        params.wetMix = 0.0f;
+        return params;
+    }
+
+    float vs3 = voxelSize * voxelSize * voxelSize;
+    float vs2 = voxelSize * voxelSize;
+    float V = static_cast<float>(zone.volume) * vs3;
+    float S = static_cast<float>(zone.surfaceArea) * vs2;
+
+    // Sabine equation: RT60 = 0.161 * V / (alpha * S)
+    constexpr float kAlphaAvg = 0.3f; // moderate absorption (stone/concrete)
+    float rt60 = 0.0f;
+    if (S > 0.0f) {
+        rt60 = 0.161f * V / (kAlphaAvg * S);
+    }
+    rt60 = std::clamp(rt60, 0.1f, 3.0f);
+
+    // Damping: ratio of surface area to volume (more surface = more absorption).
+    float damping =
+        std::clamp(static_cast<float>(zone.surfaceArea) / static_cast<float>(std::max(zone.volume, 1)), 0.1f, 0.9f);
+
+    // Wet mix: proportional to decay time, reduced by openness (sound escapes).
+    float wetMix = std::clamp(rt60 / 3.0f, 0.0f, 1.0f) * (1.0f - 0.5f * zone.openness);
+
+    params.decayTime = rt60;
+    params.damping = damping;
+    params.wetMix = wetMix;
+    return params;
+}
+
+} // namespace fabric

--- a/tests/unit/core/CMakeLists.txt
+++ b/tests/unit/core/CMakeLists.txt
@@ -71,6 +71,7 @@ target_sources(UnitTests
   ParticleSystemTest.cc
   WaterMeshTest.cc
   BVHVisitorTest.cc
+  ReverbZoneTest.cc
 )
 
 set_source_files_properties(

--- a/tests/unit/core/ReverbZoneTest.cc
+++ b/tests/unit/core/ReverbZoneTest.cc
@@ -1,0 +1,222 @@
+#include "fabric/core/ReverbZone.hh"
+#include "fabric/core/ChunkedGrid.hh"
+
+#include <gtest/gtest.h>
+
+using namespace fabric;
+
+// ---------------------------------------------------------------------------
+// Helper: build a sealed box of solid voxels with air interior.
+// Walls at [0..size-1] boundaries, air inside [1..size-2].
+// ---------------------------------------------------------------------------
+static ChunkedGrid<float> makeSealedBox(int size) {
+    ChunkedGrid<float> grid;
+    for (int x = 0; x < size; ++x) {
+        for (int y = 0; y < size; ++y) {
+            for (int z = 0; z < size; ++z) {
+                bool wall = (x == 0 || x == size - 1 || y == 0 || y == size - 1 || z == 0 || z == size - 1);
+                grid.set(x, y, z, wall ? 1.0f : 0.0f);
+            }
+        }
+    }
+    return grid;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Sealed box: volume, surface area, openness, completeness
+// ---------------------------------------------------------------------------
+TEST(ReverbZoneTest, SealedBoxMetrics) {
+    // 12x12x12 box: interior is 10x10x10 = 1000 air voxels.
+    auto grid = makeSealedBox(12);
+
+    // Start BFS inside the box.
+    auto est = estimateZone(grid, 5, 5, 5, 0.5f, 100000);
+
+    EXPECT_EQ(est.volume, 1000);
+    EXPECT_EQ(est.surfaceArea, 600); // 6 faces * 10*10
+    EXPECT_FLOAT_EQ(est.openness, 0.0f);
+    EXPECT_TRUE(est.complete);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Open area: no walls, BFS expands until budget, high openness
+// ---------------------------------------------------------------------------
+TEST(ReverbZoneTest, OpenAreaHighOpenness) {
+    // Empty grid: all voxels return default T{} = 0.0f (air).
+    ChunkedGrid<float> grid;
+
+    // Budget-limited so BFS can't go forever.
+    auto est = estimateZone(grid, 0, 0, 0, 0.5f, 500);
+
+    EXPECT_GT(est.volume, 0);
+    EXPECT_EQ(est.surfaceArea, 0); // No solid neighbors anywhere.
+    EXPECT_GT(est.openness, 0.8f);
+    EXPECT_FALSE(est.complete);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Budget cap: small budget, verify partial result
+// ---------------------------------------------------------------------------
+TEST(ReverbZoneTest, BudgetCapPartialResult) {
+    auto grid = makeSealedBox(12);
+
+    // Budget smaller than interior volume (1000).
+    auto est = estimateZone(grid, 5, 5, 5, 0.5f, 100);
+
+    EXPECT_EQ(est.volume, 100);
+    EXPECT_FALSE(est.complete);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Cache invalidation: reset() clears state
+// ---------------------------------------------------------------------------
+TEST(ReverbZoneTest, ResetClearsState) {
+    auto grid = makeSealedBox(12);
+
+    ReverbZoneEstimator estimator;
+    estimator.reset(5, 5, 5);
+    estimator.advanceBFS(grid, 0.5f, 50);
+
+    auto partial = estimator.estimate();
+    EXPECT_EQ(partial.volume, 50);
+
+    // Reset to same position: state should be fresh.
+    estimator.reset(5, 5, 5);
+    EXPECT_FALSE(estimator.isComplete());
+
+    auto afterReset = estimator.estimate();
+    EXPECT_EQ(afterReset.volume, 0);
+}
+
+// ---------------------------------------------------------------------------
+// 5. Parameter mapping: sealed box RT60 via Sabine, open area low wetMix
+// ---------------------------------------------------------------------------
+TEST(ReverbZoneTest, SealedBoxReverbParams) {
+    ZoneEstimate sealed;
+    sealed.volume = 1000;
+    sealed.surfaceArea = 600;
+    sealed.openness = 0.0f;
+    sealed.complete = true;
+
+    auto params = mapToReverbParams(sealed, 1.0f);
+
+    // Sabine: RT60 = 0.161 * 1000 / (0.3 * 600) = 161 / 180 ≈ 0.894
+    EXPECT_NEAR(params.decayTime, 0.894f, 0.01f);
+    EXPECT_GE(params.decayTime, 0.1f);
+    EXPECT_LE(params.decayTime, 3.0f);
+    EXPECT_GT(params.damping, 0.1f);
+    EXPECT_GT(params.wetMix, 0.0f);
+}
+
+TEST(ReverbZoneTest, OpenAreaLowWetMix) {
+    ZoneEstimate open;
+    open.volume = 500;
+    open.surfaceArea = 0;
+    open.openness = 0.95f;
+    open.complete = false;
+
+    auto params = mapToReverbParams(open);
+
+    // No surface area: RT60 clamped to minimum 0.1.
+    EXPECT_FLOAT_EQ(params.decayTime, 0.1f);
+    // wetMix should be low due to high openness.
+    EXPECT_LT(params.wetMix, 0.1f);
+}
+
+// ---------------------------------------------------------------------------
+// 6. Empty grid (all air): high openness
+// ---------------------------------------------------------------------------
+TEST(ReverbZoneTest, EmptyGridAllAir) {
+    ChunkedGrid<float> grid;
+
+    auto est = estimateZone(grid, 0, 0, 0, 0.5f, 1000);
+
+    EXPECT_GT(est.volume, 0);
+    EXPECT_EQ(est.surfaceArea, 0);
+    EXPECT_GT(est.openness, 0.8f);
+    EXPECT_FALSE(est.complete);
+}
+
+// ---------------------------------------------------------------------------
+// 7. Single voxel start in solid: volume = 0
+// ---------------------------------------------------------------------------
+TEST(ReverbZoneTest, StartInSolidZeroVolume) {
+    ChunkedGrid<float> grid;
+    grid.set(5, 5, 5, 1.0f); // Solid at start.
+
+    // Surround with solid so BFS can't escape.
+    for (const auto& off :
+         std::vector<std::array<int, 3>>{{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1}}) {
+        grid.set(5 + off[0], 5 + off[1], 5 + off[2], 1.0f);
+    }
+
+    auto est = estimateZone(grid, 5, 5, 5, 0.5f, 1000);
+
+    EXPECT_EQ(est.volume, 0);
+}
+
+// ---------------------------------------------------------------------------
+// 8. Incremental convergence: advanceBFS multiple times = one-shot
+// ---------------------------------------------------------------------------
+TEST(ReverbZoneTest, IncrementalConvergence) {
+    auto grid = makeSealedBox(12);
+
+    // One-shot.
+    auto oneShot = estimateZone(grid, 5, 5, 5, 0.5f, 100000);
+
+    // Incremental: many small budgets.
+    ReverbZoneEstimator estimator;
+    estimator.reset(5, 5, 5);
+    while (!estimator.isComplete()) {
+        estimator.advanceBFS(grid, 0.5f, 50);
+    }
+    auto incremental = estimator.estimate();
+
+    EXPECT_EQ(incremental.volume, oneShot.volume);
+    EXPECT_EQ(incremental.surfaceArea, oneShot.surfaceArea);
+    EXPECT_FLOAT_EQ(incremental.openness, oneShot.openness);
+    EXPECT_EQ(incremental.complete, oneShot.complete);
+}
+
+// ---------------------------------------------------------------------------
+// 9. Zero-volume zone produces safe reverb params (no division by zero)
+// ---------------------------------------------------------------------------
+TEST(ReverbZoneTest, ZeroVolumeParamsSafe) {
+    ZoneEstimate empty;
+    empty.volume = 0;
+    empty.surfaceArea = 0;
+    empty.openness = 0.0f;
+    empty.complete = true;
+
+    auto params = mapToReverbParams(empty);
+
+    EXPECT_FLOAT_EQ(params.decayTime, 0.1f);
+    EXPECT_FLOAT_EQ(params.damping, 0.9f);
+    EXPECT_FLOAT_EQ(params.wetMix, 0.0f);
+}
+
+// ---------------------------------------------------------------------------
+// 10. RT60 clamps to [0.1, 3.0] for extreme volumes
+// ---------------------------------------------------------------------------
+TEST(ReverbZoneTest, RT60ClampRange) {
+    // Large volume, tiny surface: would give huge RT60 unclamped.
+    ZoneEstimate huge;
+    huge.volume = 1000000;
+    huge.surfaceArea = 6;
+    huge.openness = 0.0f;
+    huge.complete = true;
+
+    auto params = mapToReverbParams(huge);
+    EXPECT_FLOAT_EQ(params.decayTime, 3.0f);
+
+    // Tiny volume, large surface: would give tiny RT60.
+    ZoneEstimate tiny;
+    tiny.volume = 1;
+    tiny.surfaceArea = 6;
+    tiny.openness = 0.0f;
+    tiny.complete = true;
+
+    auto paramsSmall = mapToReverbParams(tiny);
+    EXPECT_GE(paramsSmall.decayTime, 0.1f);
+    EXPECT_LE(paramsSmall.decayTime, 3.0f);
+}


### PR DESCRIPTION
## Summary

- Implements BFS flood-fill zone estimation for reverb parameter derivation (EF-16a)
- `ReverbZoneEstimator` walks 6-connected air voxels, counting volume, surface area, and openness
- `mapToReverbParams()` maps zone geometry to RT60 (Sabine equation), damping, and wet mix
- Incremental BFS via `advanceBFS()` supports per-frame budget caps for real-time use

## Details

**New files:**
- `include/fabric/core/ReverbZone.hh` — `ZoneEstimate`, `ReverbParams`, `ReverbZoneEstimator`
- `src/core/ReverbZone.cc` — BFS implementation + Sabine mapping
- `tests/unit/core/ReverbZoneTest.cc` — 11 tests covering sealed box, open area, budget cap, incremental convergence, parameter mapping, edge cases

**Sabine equation:** RT60 = 0.161 × V / (α × S), α=0.3 (stone/concrete), clamped to [0.1, 3.0]s

## Test plan

- [x] 11 new ReverbZone tests pass
- [x] Full suite 1195/1195 pass (zero regressions, +11 from dev baseline)
- [x] Sealed box: volume=1000, surfaceArea=600, openness=0.0, complete=true
- [x] Open area: surfaceArea=0, openness>0.8, complete=false
- [x] Incremental convergence matches one-shot
- [x] Zero-volume and extreme-volume edge cases safe