### PR TITLE
refactor: abstract merge criterion and LOD material reduction

### DIFF
--- a/include/recurse/simulation/CellAccessors.hh
+++ b/include/recurse/simulation/CellAccessors.hh
@@ -31,4 +31,22 @@ inline bool canDisplace(const MaterialRegistry& registry, VoxelCell mover, Voxel
     return moverDef.density > targetDef.density;
 }
 
+/// Merge key for greedy meshing. Adjacent faces with equal keys are merged
+/// into a single quad. Initially maps to materialId; Wave 4 swaps to a
+/// visual-equivalence hash derived from MatterState fields.
+using MergeKey = uint16_t;
+
+/// Sentinel value indicating an empty (unmergeable) face slot in the mask.
+inline constexpr MergeKey K_MERGE_KEY_EMPTY = static_cast<MergeKey>(material_ids::AIR);
+
+/// Extract the merge key from a cell for the greedy mesher mask array.
+inline MergeKey mergeKey(VoxelCell cell) {
+    return cell.materialId;
+}
+
+/// True when two adjacent face slots can be merged into a single greedy quad.
+inline bool canMergeQuads(MergeKey a, MergeKey b) {
+    return a == b;
+}
+
 } // namespace recurse::simulation

--- a/include/recurse/simulation/CellAccessors.hh
+++ b/include/recurse/simulation/CellAccessors.hh
@@ -31,6 +31,32 @@ inline bool canDisplace(const MaterialRegistry& registry, VoxelCell mover, Voxel
     return moverDef.density > targetDef.density;
 }
 
+/// Extract the raw material id from a cell. Quarantines direct field access
+/// so the LOD and debug paths route through a single point that changes
+/// when Wave 4 swaps the cell layout.
+constexpr MaterialId cellMaterialId(VoxelCell cell) {
+    return cell.materialId;
+}
+
+/// Semantic priority for LOD material reduction. Higher values win tiebreaks
+/// during 2x2x2 downsampling. The body stays as-is; quarantined here so
+/// consumers do not switch on raw materialId constants directly.
+inline int materialSemanticPriority(uint16_t materialId) {
+    switch (materialId) {
+        case material_ids::SAND:
+        case material_ids::GRAVEL:
+            return 4;
+        case material_ids::WATER:
+            return 3;
+        case material_ids::DIRT:
+            return 2;
+        case material_ids::STONE:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
 /// Merge key for greedy meshing. Adjacent faces with equal keys are merged
 /// into a single quad. Initially maps to materialId; Wave 4 swaps to a
 /// visual-equivalence hash derived from MatterState fields.

--- a/src/recurse/render/LODGrid.cc
+++ b/src/recurse/render/LODGrid.cc
@@ -1,6 +1,7 @@
 #include "recurse/render/LODGrid.hh"
 
 #include "fabric/log/Log.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 #include <algorithm>
 #include <array>
@@ -16,22 +17,6 @@ struct MaterialTally {
     int weightedScore = 0;
     int sampleCount = 0;
 };
-
-int materialSemanticPriority(uint16_t materialId) {
-    switch (materialId) {
-        case simulation::material_ids::SAND:
-        case simulation::material_ids::GRAVEL:
-            return 4;
-        case simulation::material_ids::WATER:
-            return 3;
-        case simulation::material_ids::DIRT:
-            return 2;
-        case simulation::material_ids::STONE:
-            return 1;
-        default:
-            return 0;
-    }
-}
 
 void accumulateMaterialTally(std::array<MaterialTally, 8>& tallies, int& tallyCount, uint16_t materialId, int weight) {
     for (int i = 0; i < tallyCount; ++i) {
@@ -79,7 +64,7 @@ uint16_t reduceMaterialGroup(const LODSection& child, int clx, int cly, int clz)
     int bestPriority = -1;
     for (int i = 0; i < tallyCount; ++i) {
         const auto& tally = tallies[static_cast<size_t>(i)];
-        const int priority = materialSemanticPriority(tally.materialId);
+        const int priority = simulation::materialSemanticPriority(tally.materialId);
         const bool isBetter =
             tally.weightedScore > bestScore || (tally.weightedScore == bestScore && tally.sampleCount > bestCount) ||
             (tally.weightedScore == bestScore && tally.sampleCount == bestCount && priority > bestPriority) ||

--- a/src/recurse/systems/LODSystem.cc
+++ b/src/recurse/systems/LODSystem.cc
@@ -13,6 +13,7 @@
 #include "fabric/world/ChunkedGrid.hh"
 #include "recurse/render/LODGrid.hh"
 #include "recurse/render/LODMeshManager.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/MaterialRegistry.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
@@ -62,8 +63,8 @@ void fillLODSectionTask(const LODGenTask& task, recurse::simulation::SimulationG
                 int wy = section->origin.y + ly;
                 int wz = section->origin.z + lz;
 
-                uint16_t matId =
-                    task.useWorldGen ? gen->sampleMaterial(wx, wy, wz) : grid->readCell(wx, wy, wz).materialId;
+                uint16_t matId = task.useWorldGen ? gen->sampleMaterial(wx, wy, wz)
+                                                  : simulation::cellMaterialId(grid->readCell(wx, wy, wz));
 
                 uint16_t palIdx = 0;
                 auto it = std::find(section->palette.begin(), section->palette.end(), matId);

--- a/src/recurse/systems/VoxelMeshingSystem.cc
+++ b/src/recurse/systems/VoxelMeshingSystem.cc
@@ -173,13 +173,16 @@ recurse::SmoothChunkMeshData buildGreedyMesh(const MeshingChunkContext& ctx,
     output.vertices.reserve(1024);
     output.indices.reserve(1536);
 
-    std::array<uint16_t, K_CHUNK_SIZE * K_CHUNK_SIZE> mask{};
+    using recurse::simulation::K_MERGE_KEY_EMPTY;
+    using recurse::simulation::MergeKey;
+
+    std::array<MergeKey, K_CHUNK_SIZE * K_CHUNK_SIZE> mask{};
     std::array<bool, K_CHUNK_SIZE * K_CHUNK_SIZE> consumed{};
 
     for (int axis = 0; axis < K_FACE_AXIS_COUNT; ++axis) {
         for (bool positive : {false, true}) {
             for (int slice = 0; slice < K_CHUNK_SIZE; ++slice) {
-                mask.fill(recurse::simulation::material_ids::AIR);
+                mask.fill(K_MERGE_KEY_EMPTY);
                 consumed.fill(false);
 
                 for (int row = 0; row < K_CHUNK_SIZE; ++row) {
@@ -192,21 +195,21 @@ recurse::SmoothChunkMeshData buildGreedyMesh(const MeshingChunkContext& ctx,
                         if (isSolidVoxel(neighbor))
                             continue;
 
-                        mask[static_cast<size_t>(row * K_CHUNK_SIZE + col)] = cell.materialId;
+                        mask[static_cast<size_t>(row * K_CHUNK_SIZE + col)] = recurse::simulation::mergeKey(cell);
                     }
                 }
 
                 for (int row = 0; row < K_CHUNK_SIZE; ++row) {
                     for (int col = 0; col < K_CHUNK_SIZE; ++col) {
                         const size_t startIdx = static_cast<size_t>(row * K_CHUNK_SIZE + col);
-                        const uint16_t materialId = mask[startIdx];
-                        if (materialId == recurse::simulation::material_ids::AIR || consumed[startIdx])
+                        const MergeKey key = mask[startIdx];
+                        if (key == K_MERGE_KEY_EMPTY || consumed[startIdx])
                             continue;
 
                         int width = 1;
                         while (col + width < K_CHUNK_SIZE) {
                             const size_t idx = static_cast<size_t>(row * K_CHUNK_SIZE + col + width);
-                            if (mask[idx] != materialId || consumed[idx])
+                            if (!recurse::simulation::canMergeQuads(mask[idx], key) || consumed[idx])
                                 break;
                             ++width;
                         }
@@ -216,7 +219,7 @@ recurse::SmoothChunkMeshData buildGreedyMesh(const MeshingChunkContext& ctx,
                         while (row + height < K_CHUNK_SIZE && canGrow) {
                             for (int offset = 0; offset < width; ++offset) {
                                 const size_t idx = static_cast<size_t>((row + height) * K_CHUNK_SIZE + col + offset);
-                                if (mask[idx] != materialId || consumed[idx]) {
+                                if (!recurse::simulation::canMergeQuads(mask[idx], key) || consumed[idx]) {
                                     canGrow = false;
                                     break;
                                 }
@@ -231,7 +234,7 @@ recurse::SmoothChunkMeshData buildGreedyMesh(const MeshingChunkContext& ctx,
                             }
                         }
 
-                        emitGreedyQuad(output, axis, positive, slice, row, col, width, height, materialId);
+                        emitGreedyQuad(output, axis, positive, slice, row, col, width, height, key);
                     }
                 }
             }
@@ -527,7 +530,7 @@ CPUMeshResult VoxelMeshingSystem::generateMeshCPU(const fabric::ChunkCoord& coor
                         const auto cell = meshCtx.readLocal(lx, ly, lz, simGrid_);
                         const float density = recurse::simulation::isEmpty(cell) ? 0.0f : 1.0f;
                         densityGrid.set(baseX + lx, baseY + ly, baseZ + lz, density);
-                        materialGrid.set(baseX + lx, baseY + ly, baseZ + lz, cell.materialId);
+                        materialGrid.set(baseX + lx, baseY + ly, baseZ + lz, recurse::simulation::mergeKey(cell));
                     }
                 }
             }

--- a/src/recurse/systems/VoxelMeshingSystem.cc
+++ b/src/recurse/systems/VoxelMeshingSystem.cc
@@ -177,12 +177,14 @@ recurse::SmoothChunkMeshData buildGreedyMesh(const MeshingChunkContext& ctx,
     using recurse::simulation::MergeKey;
 
     std::array<MergeKey, K_CHUNK_SIZE * K_CHUNK_SIZE> mask{};
+    std::array<uint16_t, K_CHUNK_SIZE * K_CHUNK_SIZE> materialIds{};
     std::array<bool, K_CHUNK_SIZE * K_CHUNK_SIZE> consumed{};
 
     for (int axis = 0; axis < K_FACE_AXIS_COUNT; ++axis) {
         for (bool positive : {false, true}) {
             for (int slice = 0; slice < K_CHUNK_SIZE; ++slice) {
                 mask.fill(K_MERGE_KEY_EMPTY);
+                materialIds.fill(0);
                 consumed.fill(false);
 
                 for (int row = 0; row < K_CHUNK_SIZE; ++row) {
@@ -195,7 +197,9 @@ recurse::SmoothChunkMeshData buildGreedyMesh(const MeshingChunkContext& ctx,
                         if (isSolidVoxel(neighbor))
                             continue;
 
-                        mask[static_cast<size_t>(row * K_CHUNK_SIZE + col)] = recurse::simulation::mergeKey(cell);
+                        const size_t maskIdx = static_cast<size_t>(row * K_CHUNK_SIZE + col);
+                        mask[maskIdx] = recurse::simulation::mergeKey(cell);
+                        materialIds[maskIdx] = recurse::simulation::cellMaterialId(cell);
                     }
                 }
 
@@ -234,7 +238,7 @@ recurse::SmoothChunkMeshData buildGreedyMesh(const MeshingChunkContext& ctx,
                             }
                         }
 
-                        emitGreedyQuad(output, axis, positive, slice, row, col, width, height, key);
+                        emitGreedyQuad(output, axis, positive, slice, row, col, width, height, materialIds[startIdx]);
                     }
                 }
             }
@@ -530,7 +534,7 @@ CPUMeshResult VoxelMeshingSystem::generateMeshCPU(const fabric::ChunkCoord& coor
                         const auto cell = meshCtx.readLocal(lx, ly, lz, simGrid_);
                         const float density = recurse::simulation::isEmpty(cell) ? 0.0f : 1.0f;
                         densityGrid.set(baseX + lx, baseY + ly, baseZ + lz, density);
-                        materialGrid.set(baseX + lx, baseY + ly, baseZ + lz, recurse::simulation::mergeKey(cell));
+                        materialGrid.set(baseX + lx, baseY + ly, baseZ + lz, recurse::simulation::cellMaterialId(cell));
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Extract greedy mesher merge criterion behind `canMergeQuads` predicate with `MergeKey` type alias
- Abstract LOD material reduction behind semantic interface
- Part of Wave 2 of the MatterState migration (Track A: accessor quarantine)

## Changes
- Introduce `MergeKey` type alias, `mergeKey(cell)` extractor, and `canMergeQuads(a, b)` predicate
- Replace raw `materialId` equality checks in greedy mesher with predicate calls
- Add `cellMaterialId(cell)` accessor for LOD section fill
- Move `materialSemanticPriority()` into `CellAccessors.hh` to quarantine raw materialId switch
- Quarantine direct cell reads in LOD code behind accessors

## Test plan
- [x] `mise run build` passes
- [x] `mise run test` passes (2211/2211)
- [x] `mise run lint:changed` passes
- [ ] Visual verification: terrain renders identically

Closes #53, #54
Resolves #76