### PR TITLE
feat: define MatterState v1 types and ProjectionRuleTable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,7 @@ set(FABRIC_SIMULATION_SOURCE_FILES
     src/recurse/simulation/VoxelSimulationSystem.cc
     src/recurse/simulation/EssenceAssigner.cc
     src/recurse/simulation/ChangeVelocityTracker.cc
+    src/recurse/simulation/ProjectionRuleTable.cc
 )
 
 # Utils library components

--- a/include/recurse/simulation/CellAccessors.hh
+++ b/include/recurse/simulation/CellAccessors.hh
@@ -1,7 +1,10 @@
 #pragma once
 
 #include "recurse/simulation/MaterialRegistry.hh"
+#include "recurse/simulation/MatterState.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
+
+#include <concepts>
 
 namespace recurse::simulation {
 
@@ -30,6 +33,66 @@ inline bool canDisplace(const MaterialRegistry& registry, VoxelCell mover, Voxel
     const auto& moverDef = registry.get(mover.materialId);
     return moverDef.density > targetDef.density;
 }
+
+// -- MatterState overloads --------------------------------------------------
+
+/// True when the MatterState cell is occupied (not Empty phase).
+constexpr bool isOccupied(MatterState cell) {
+    return cell.phase() != Phase::Empty;
+}
+
+/// True when the MatterState cell is empty.
+constexpr bool isEmpty(MatterState cell) {
+    return cell.phase() == Phase::Empty;
+}
+
+/// Returns the cell phase from MatterState directly. Registry parameter is
+/// accepted for concept satisfaction but unused; MatterState carries its phase.
+inline MoveType cellPhase(const MaterialRegistry& /*registry*/, MatterState cell) {
+    switch (cell.phase()) {
+        case Phase::Solid:
+            return MoveType::Static;
+        case Phase::Powder:
+            return MoveType::Powder;
+        case Phase::Liquid:
+        case Phase::Gas:
+            return MoveType::Liquid; // Gas placeholder until MoveType::Gas exists
+        default:
+            return MoveType::Static;
+    }
+}
+
+/// Displacement check for MatterState cells. Uses displacementRank directly.
+inline bool canDisplace(const MaterialRegistry& /*registry*/, MatterState mover, MatterState target) {
+    if (isEmpty(target))
+        return true;
+    if (target.phase() == Phase::Solid)
+        return false;
+    return mover.displacementRank > target.displacementRank;
+}
+
+// -- Cell concepts ----------------------------------------------------------
+
+/// A cell type that supports occupancy queries without external context.
+template <typename T>
+concept CellQuery = requires(T cell) {
+    { isOccupied(cell) } -> std::convertible_to<bool>;
+    { isEmpty(cell) } -> std::convertible_to<bool>;
+};
+
+/// A cell type that supports semantic queries requiring registry context.
+template <typename T>
+concept SemanticQuery = CellQuery<T> && requires(const MaterialRegistry& reg, T cell, T other) {
+    { cellPhase(reg, cell) } -> std::convertible_to<MoveType>;
+    { canDisplace(reg, cell, other) } -> std::convertible_to<bool>;
+};
+
+static_assert(CellQuery<VoxelCell>, "VoxelCell must satisfy CellQuery");
+static_assert(CellQuery<MatterState>, "MatterState must satisfy CellQuery");
+static_assert(SemanticQuery<VoxelCell>, "VoxelCell must satisfy SemanticQuery");
+static_assert(SemanticQuery<MatterState>, "MatterState must satisfy SemanticQuery");
+
+// ---------------------------------------------------------------------------
 
 /// Extract the raw material id from a cell. Quarantines direct field access
 /// so the LOD and debug paths route through a single point that changes

--- a/include/recurse/simulation/CellAccessors.hh
+++ b/include/recurse/simulation/CellAccessors.hh
@@ -55,8 +55,9 @@ inline MoveType cellPhase(const MaterialRegistry& /*registry*/, MatterState cell
         case Phase::Powder:
             return MoveType::Powder;
         case Phase::Liquid:
+            return MoveType::Liquid;
         case Phase::Gas:
-            return MoveType::Liquid; // Gas placeholder until MoveType::Gas exists
+            return MoveType::Gas;
         default:
             return MoveType::Static;
     }

--- a/include/recurse/simulation/MatterState.hh
+++ b/include/recurse/simulation/MatterState.hh
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+
+namespace recurse::simulation {
+
+/// Broad matter mode for a voxel cell.
+/// Values 5-7 reserved for future use (Growth, Unstable, etc.).
+enum class Phase : uint8_t {
+    Empty = 0,
+    Solid = 1,
+    Powder = 2,
+    Liquid = 3,
+    Gas = 4
+};
+
+/// MatterState v1: 4-byte cell layout for essence-first world authority.
+/// Shape C: essenceIdx(8b) + displacementRank(8b) + phase(3b) + flags(5b) + spare(8b).
+struct MatterState {
+    uint8_t essenceIdx{0};       ///< Palette index into per-chunk EssencePalette.
+    uint8_t displacementRank{0}; ///< CA displacement ordering (0-255). Replaces MaterialDef::density.
+    uint8_t phaseAndFlags{0};    ///< Low 3 bits = Phase, high 5 bits = flags.
+    uint8_t spare{0};            ///< Reserved, must be 0 in v1.
+
+    constexpr Phase phase() const { return static_cast<Phase>(phaseAndFlags & 0x07); }
+
+    constexpr void setPhase(Phase p) {
+        phaseAndFlags = static_cast<uint8_t>((phaseAndFlags & 0xF8) | (static_cast<uint8_t>(p) & 0x07));
+    }
+
+    constexpr uint8_t flags() const { return (phaseAndFlags >> 3) & 0x1F; }
+
+    constexpr void setFlags(uint8_t f) {
+        phaseAndFlags = static_cast<uint8_t>((phaseAndFlags & 0x07) | ((f & 0x1F) << 3));
+    }
+};
+
+static_assert(sizeof(MatterState) == 4, "MatterState must be exactly 4 bytes");
+
+} // namespace recurse::simulation

--- a/include/recurse/simulation/ProjectionRuleTable.hh
+++ b/include/recurse/simulation/ProjectionRuleTable.hh
@@ -18,7 +18,7 @@ struct ProjectedMaterial {
     std::string_view displayName{};
     uint32_t baseColor{0};
     uint8_t soundCategory{0};
-    uint8_t semanticPriority{0};
+    uint8_t reductionTiebreak{0};
     MoveType moveType{MoveType::Static};
     uint8_t density{0};
 };

--- a/include/recurse/simulation/ProjectionRuleTable.hh
+++ b/include/recurse/simulation/ProjectionRuleTable.hh
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "recurse/simulation/MatterState.hh"
+#include "recurse/simulation/VoxelMaterial.hh"
+#include <array>
+#include <cstdint>
+#include <string_view>
+
+namespace recurse::simulation {
+
+class MaterialRegistry; // forward declare
+
+/// Projected material properties derived from semantic cell state.
+/// Pure downstream cache; never world authority.
+/// Note: string_view for displayName means pointed-to strings must outlive the table.
+/// For defaults populated from string literals, this is safe.
+struct ProjectedMaterial {
+    std::string_view displayName{};
+    uint32_t baseColor{0};
+    uint8_t soundCategory{0};
+    uint8_t semanticPriority{0};
+    MoveType moveType{MoveType::Static};
+    uint8_t density{0};
+};
+
+static_assert(std::is_trivially_copyable_v<ProjectedMaterial>, "ProjectedMaterial must be trivially copyable");
+
+/// Runtime-configurable projection from semantic cell state to material properties.
+/// Maps (essenceIdx, phase) -> ProjectedMaterial.
+///
+/// Primary lookup keys on essenceIdx * K_PHASE_COUNT + phase.
+/// displacementRank-dependent overrides are not part of v1.
+class ProjectionRuleTable {
+  public:
+    static constexpr size_t K_PHASE_COUNT = 5;
+    static constexpr size_t K_MAX_ESSENCE = 256;
+    static constexpr size_t K_TABLE_SIZE = K_MAX_ESSENCE * K_PHASE_COUNT;
+
+    ProjectionRuleTable();
+
+    /// Look up projected material for the given semantic state.
+    const ProjectedMaterial& lookup(uint8_t essenceIdx, Phase phase) const;
+
+    /// Override a single rule entry.
+    void setRule(uint8_t essenceIdx, Phase phase, const ProjectedMaterial& mat);
+
+    /// Bulk-populate from existing MaterialRegistry.
+    /// Maps each registered MaterialId to its corresponding essenceIdx slot.
+    /// This preserves identical behavior during migration.
+    void populateFromRegistry(const MaterialRegistry& registry);
+
+  private:
+    size_t index(uint8_t essenceIdx, Phase phase) const;
+    std::array<ProjectedMaterial, K_TABLE_SIZE> table_{};
+};
+
+} // namespace recurse::simulation

--- a/include/recurse/simulation/ProjectionRuleTable.hh
+++ b/include/recurse/simulation/ProjectionRuleTable.hh
@@ -32,7 +32,7 @@ static_assert(std::is_trivially_copyable_v<ProjectedMaterial>, "ProjectedMateria
 /// displacementRank-dependent overrides are not part of v1.
 class ProjectionRuleTable {
   public:
-    static constexpr size_t K_PHASE_COUNT = 5;
+    static constexpr size_t K_PHASE_COUNT = 8;
     static constexpr size_t K_MAX_ESSENCE = 256;
     static constexpr size_t K_TABLE_SIZE = K_MAX_ESSENCE * K_PHASE_COUNT;
 

--- a/src/recurse/simulation/ProjectionRuleTable.cc
+++ b/src/recurse/simulation/ProjectionRuleTable.cc
@@ -1,0 +1,61 @@
+#include "recurse/simulation/ProjectionRuleTable.hh"
+#include "recurse/simulation/MaterialRegistry.hh"
+
+namespace recurse::simulation {
+
+ProjectionRuleTable::ProjectionRuleTable() = default;
+
+size_t ProjectionRuleTable::index(uint8_t essenceIdx, Phase phase) const {
+    return static_cast<size_t>(essenceIdx) * K_PHASE_COUNT + static_cast<size_t>(static_cast<uint8_t>(phase));
+}
+
+const ProjectedMaterial& ProjectionRuleTable::lookup(uint8_t essenceIdx, Phase phase) const {
+    return table_[index(essenceIdx, phase)];
+}
+
+void ProjectionRuleTable::setRule(uint8_t essenceIdx, Phase phase, const ProjectedMaterial& mat) {
+    table_[index(essenceIdx, phase)] = mat;
+}
+
+void ProjectionRuleTable::populateFromRegistry(const MaterialRegistry& registry) {
+    // During migration, MaterialId maps 1:1 to essenceIdx for registered materials.
+    for (MaterialId id = 0; id < registry.count(); ++id) {
+        const auto& def = registry.get(id);
+
+        // Derive phase from MoveType (mirrors CellAccessors.hh cellPhase logic)
+        Phase phase = Phase::Empty;
+        if (id == material_ids::AIR) {
+            phase = Phase::Empty;
+        } else {
+            switch (def.moveType) {
+                case MoveType::Static:
+                    phase = Phase::Solid;
+                    break;
+                case MoveType::Powder:
+                    phase = Phase::Powder;
+                    break;
+                case MoveType::Liquid:
+                    phase = Phase::Liquid;
+                    break;
+                case MoveType::Gas:
+                    phase = Phase::Gas;
+                    break;
+                default:
+                    phase = Phase::Solid;
+                    break;
+            }
+        }
+
+        ProjectedMaterial projected;
+        projected.baseColor = def.baseColor;
+        projected.moveType = def.moveType;
+        projected.density = def.density;
+        projected.semanticPriority = def.density;
+        // displayName left empty for v1; B8 (debug/WAILA) will wire names.
+        projected.displayName = {};
+
+        setRule(static_cast<uint8_t>(id), phase, projected);
+    }
+}
+
+} // namespace recurse::simulation

--- a/src/recurse/simulation/ProjectionRuleTable.cc
+++ b/src/recurse/simulation/ProjectionRuleTable.cc
@@ -1,14 +1,11 @@
 #include "recurse/simulation/ProjectionRuleTable.hh"
 #include "recurse/simulation/MaterialRegistry.hh"
 
-#include <cassert>
-
 namespace recurse::simulation {
 
 ProjectionRuleTable::ProjectionRuleTable() = default;
 
 size_t ProjectionRuleTable::index(uint8_t essenceIdx, Phase phase) const {
-    assert(static_cast<uint8_t>(phase) < K_PHASE_COUNT && "Phase value out of valid range");
     return static_cast<size_t>(essenceIdx) * K_PHASE_COUNT + static_cast<size_t>(static_cast<uint8_t>(phase));
 }
 
@@ -23,6 +20,9 @@ void ProjectionRuleTable::setRule(uint8_t essenceIdx, Phase phase, const Project
 void ProjectionRuleTable::populateFromRegistry(const MaterialRegistry& registry) {
     // During migration, MaterialId maps 1:1 to essenceIdx for registered materials.
     for (MaterialId id = 0; id < registry.count(); ++id) {
+        if (id >= K_MAX_ESSENCE) {
+            continue;
+        }
         const auto& def = registry.get(id);
 
         // Derive phase from MoveType (mirrors CellAccessors.hh cellPhase logic)

--- a/src/recurse/simulation/ProjectionRuleTable.cc
+++ b/src/recurse/simulation/ProjectionRuleTable.cc
@@ -1,11 +1,14 @@
 #include "recurse/simulation/ProjectionRuleTable.hh"
 #include "recurse/simulation/MaterialRegistry.hh"
 
+#include <cassert>
+
 namespace recurse::simulation {
 
 ProjectionRuleTable::ProjectionRuleTable() = default;
 
 size_t ProjectionRuleTable::index(uint8_t essenceIdx, Phase phase) const {
+    assert(static_cast<uint8_t>(phase) < K_PHASE_COUNT && "Phase value out of valid range");
     return static_cast<size_t>(essenceIdx) * K_PHASE_COUNT + static_cast<size_t>(static_cast<uint8_t>(phase));
 }
 
@@ -50,7 +53,7 @@ void ProjectionRuleTable::populateFromRegistry(const MaterialRegistry& registry)
         projected.baseColor = def.baseColor;
         projected.moveType = def.moveType;
         projected.density = def.density;
-        projected.semanticPriority = def.density;
+        projected.reductionTiebreak = def.density;
         // displayName left empty for v1; B8 (debug/WAILA) will wire names.
         projected.displayName = {};
 

--- a/tests/unit/simulation/CMakeLists.txt
+++ b/tests/unit/simulation/CMakeLists.txt
@@ -14,4 +14,5 @@ target_sources(UnitTests
   ParallelSimulationTest.cc
   ChangeVelocityTrackerTest.cc
   BoundaryDrainTest.cc
+  MatterStateTest.cc
 )

--- a/tests/unit/simulation/CMakeLists.txt
+++ b/tests/unit/simulation/CMakeLists.txt
@@ -15,4 +15,5 @@ target_sources(UnitTests
   ChangeVelocityTrackerTest.cc
   BoundaryDrainTest.cc
   MatterStateTest.cc
+  ProjectionRuleTableTest.cc
 )

--- a/tests/unit/simulation/MatterStateTest.cc
+++ b/tests/unit/simulation/MatterStateTest.cc
@@ -116,9 +116,8 @@ TEST(MatterStateTest, CellPhaseMapping) {
     cell.setPhase(Phase::Liquid);
     EXPECT_EQ(cellPhase(registry, cell), MoveType::Liquid);
 
-    // Gas maps to Liquid as placeholder
     cell.setPhase(Phase::Gas);
-    EXPECT_EQ(cellPhase(registry, cell), MoveType::Liquid);
+    EXPECT_EQ(cellPhase(registry, cell), MoveType::Gas);
 
     cell.setPhase(Phase::Empty);
     EXPECT_EQ(cellPhase(registry, cell), MoveType::Static);

--- a/tests/unit/simulation/MatterStateTest.cc
+++ b/tests/unit/simulation/MatterStateTest.cc
@@ -1,0 +1,180 @@
+#include "recurse/simulation/MatterState.hh"
+#include "recurse/simulation/CellAccessors.hh"
+
+#include <gtest/gtest.h>
+
+using namespace recurse::simulation;
+
+// -- MatterState layout -----------------------------------------------------
+
+TEST(MatterStateTest, SizeIs4Bytes) {
+    EXPECT_EQ(sizeof(MatterState), 4u);
+}
+
+TEST(MatterStateTest, DefaultIsAllZero) {
+    MatterState cell;
+    EXPECT_EQ(cell.essenceIdx, 0);
+    EXPECT_EQ(cell.displacementRank, 0);
+    EXPECT_EQ(cell.phaseAndFlags, 0);
+    EXPECT_EQ(cell.spare, 0);
+}
+
+TEST(MatterStateTest, DefaultPhaseIsEmpty) {
+    MatterState cell;
+    EXPECT_EQ(cell.phase(), Phase::Empty);
+}
+
+// -- Phase round-trip -------------------------------------------------------
+
+TEST(MatterStateTest, SetPhaseRoundTrip) {
+    MatterState cell;
+    const Phase phases[] = {Phase::Empty, Phase::Solid, Phase::Powder, Phase::Liquid, Phase::Gas};
+    for (auto p : phases) {
+        cell.setPhase(p);
+        EXPECT_EQ(cell.phase(), p);
+    }
+}
+
+TEST(MatterStateTest, SetPhaseDoesNotCorruptFlags) {
+    MatterState cell;
+    cell.setFlags(0x1F); // all 5 flag bits set
+    cell.setPhase(Phase::Liquid);
+    EXPECT_EQ(cell.phase(), Phase::Liquid);
+    EXPECT_EQ(cell.flags(), 0x1F);
+}
+
+// -- Flags round-trip -------------------------------------------------------
+
+TEST(MatterStateTest, SetFlagsRoundTrip) {
+    MatterState cell;
+    for (uint8_t f = 0; f <= 0x1F; ++f) {
+        cell.setFlags(f);
+        EXPECT_EQ(cell.flags(), f);
+    }
+}
+
+TEST(MatterStateTest, SetFlagsDoesNotCorruptPhase) {
+    MatterState cell;
+    cell.setPhase(Phase::Gas);
+    cell.setFlags(0x15);
+    EXPECT_EQ(cell.phase(), Phase::Gas);
+    EXPECT_EQ(cell.flags(), 0x15);
+}
+
+// -- Field isolation --------------------------------------------------------
+
+TEST(MatterStateTest, DisplacementRankIsolated) {
+    MatterState cell;
+    cell.displacementRank = 200;
+    cell.setPhase(Phase::Powder);
+    cell.setFlags(0x0A);
+    EXPECT_EQ(cell.displacementRank, 200);
+    EXPECT_EQ(cell.essenceIdx, 0);
+    EXPECT_EQ(cell.spare, 0);
+}
+
+TEST(MatterStateTest, EssenceIdxIsolated) {
+    MatterState cell;
+    cell.essenceIdx = 42;
+    cell.displacementRank = 130;
+    cell.setPhase(Phase::Solid);
+    EXPECT_EQ(cell.essenceIdx, 42);
+    EXPECT_EQ(cell.displacementRank, 130);
+}
+
+// -- CellAccessors: isOccupied / isEmpty for MatterState --------------------
+
+TEST(MatterStateTest, EmptyPhaseIsEmpty) {
+    MatterState cell;
+    cell.setPhase(Phase::Empty);
+    EXPECT_TRUE(isEmpty(cell));
+    EXPECT_FALSE(isOccupied(cell));
+}
+
+TEST(MatterStateTest, NonEmptyPhaseIsOccupied) {
+    MatterState cell;
+    const Phase occupied[] = {Phase::Solid, Phase::Powder, Phase::Liquid, Phase::Gas};
+    for (auto p : occupied) {
+        cell.setPhase(p);
+        EXPECT_TRUE(isOccupied(cell));
+        EXPECT_FALSE(isEmpty(cell));
+    }
+}
+
+// -- CellAccessors: cellPhase for MatterState -------------------------------
+
+TEST(MatterStateTest, CellPhaseMapping) {
+    MaterialRegistry registry;
+    MatterState cell;
+
+    cell.setPhase(Phase::Solid);
+    EXPECT_EQ(cellPhase(registry, cell), MoveType::Static);
+
+    cell.setPhase(Phase::Powder);
+    EXPECT_EQ(cellPhase(registry, cell), MoveType::Powder);
+
+    cell.setPhase(Phase::Liquid);
+    EXPECT_EQ(cellPhase(registry, cell), MoveType::Liquid);
+
+    // Gas maps to Liquid as placeholder
+    cell.setPhase(Phase::Gas);
+    EXPECT_EQ(cellPhase(registry, cell), MoveType::Liquid);
+
+    cell.setPhase(Phase::Empty);
+    EXPECT_EQ(cellPhase(registry, cell), MoveType::Static);
+}
+
+// -- CellAccessors: canDisplace for MatterState -----------------------------
+
+TEST(MatterStateTest, CanDisplaceEmptyTarget) {
+    MaterialRegistry registry;
+    MatterState mover;
+    mover.setPhase(Phase::Powder);
+    mover.displacementRank = 100;
+
+    MatterState target;
+    target.setPhase(Phase::Empty);
+
+    EXPECT_TRUE(canDisplace(registry, mover, target));
+}
+
+TEST(MatterStateTest, CannotDisplaceSolid) {
+    MaterialRegistry registry;
+    MatterState mover;
+    mover.setPhase(Phase::Liquid);
+    mover.displacementRank = 255;
+
+    MatterState target;
+    target.setPhase(Phase::Solid);
+    target.displacementRank = 1;
+
+    EXPECT_FALSE(canDisplace(registry, mover, target));
+}
+
+TEST(MatterStateTest, DisplacementRankOrdering) {
+    MaterialRegistry registry;
+    MatterState heavy;
+    heavy.setPhase(Phase::Powder);
+    heavy.displacementRank = 200;
+
+    MatterState light;
+    light.setPhase(Phase::Liquid);
+    light.displacementRank = 100;
+
+    EXPECT_TRUE(canDisplace(registry, heavy, light));
+    EXPECT_FALSE(canDisplace(registry, light, heavy));
+}
+
+TEST(MatterStateTest, EqualRankCannotDisplace) {
+    MaterialRegistry registry;
+    MatterState a;
+    a.setPhase(Phase::Powder);
+    a.displacementRank = 100;
+
+    MatterState b;
+    b.setPhase(Phase::Liquid);
+    b.displacementRank = 100;
+
+    EXPECT_FALSE(canDisplace(registry, a, b));
+    EXPECT_FALSE(canDisplace(registry, b, a));
+}

--- a/tests/unit/simulation/ProjectionRuleTableTest.cc
+++ b/tests/unit/simulation/ProjectionRuleTableTest.cc
@@ -12,7 +12,7 @@ TEST(ProjectionRuleTableTest, DefaultLookupReturnsEmptyMaterial) {
     const auto& mat = table.lookup(0, Phase::Empty);
     EXPECT_EQ(mat.baseColor, 0u);
     EXPECT_EQ(mat.soundCategory, 0);
-    EXPECT_EQ(mat.semanticPriority, 0);
+    EXPECT_EQ(mat.reductionTiebreak, 0);
     EXPECT_EQ(mat.moveType, MoveType::Static);
     EXPECT_EQ(mat.density, 0);
     EXPECT_TRUE(mat.displayName.empty());
@@ -34,7 +34,7 @@ TEST(ProjectionRuleTableTest, SetRuleLookupRoundTrip) {
     rule.displayName = "TestMaterial";
     rule.baseColor = 0xFFAA5500;
     rule.soundCategory = 3;
-    rule.semanticPriority = 10;
+    rule.reductionTiebreak = 10;
     rule.moveType = MoveType::Powder;
     rule.density = 130;
 
@@ -44,7 +44,7 @@ TEST(ProjectionRuleTableTest, SetRuleLookupRoundTrip) {
     EXPECT_EQ(result.displayName, "TestMaterial");
     EXPECT_EQ(result.baseColor, 0xFFAA5500u);
     EXPECT_EQ(result.soundCategory, 3);
-    EXPECT_EQ(result.semanticPriority, 10);
+    EXPECT_EQ(result.reductionTiebreak, 10);
     EXPECT_EQ(result.moveType, MoveType::Powder);
     EXPECT_EQ(result.density, 130);
 }

--- a/tests/unit/simulation/ProjectionRuleTableTest.cc
+++ b/tests/unit/simulation/ProjectionRuleTableTest.cc
@@ -1,0 +1,184 @@
+#include "recurse/simulation/ProjectionRuleTable.hh"
+#include "recurse/simulation/MaterialRegistry.hh"
+
+#include <gtest/gtest.h>
+
+using namespace recurse::simulation;
+
+// -- Default construction -----------------------------------------------------
+
+TEST(ProjectionRuleTableTest, DefaultLookupReturnsEmptyMaterial) {
+    ProjectionRuleTable table;
+    const auto& mat = table.lookup(0, Phase::Empty);
+    EXPECT_EQ(mat.baseColor, 0u);
+    EXPECT_EQ(mat.soundCategory, 0);
+    EXPECT_EQ(mat.semanticPriority, 0);
+    EXPECT_EQ(mat.moveType, MoveType::Static);
+    EXPECT_EQ(mat.density, 0);
+    EXPECT_TRUE(mat.displayName.empty());
+}
+
+TEST(ProjectionRuleTableTest, DefaultLookupNonZeroIndexReturnsEmpty) {
+    ProjectionRuleTable table;
+    const auto& mat = table.lookup(42, Phase::Solid);
+    EXPECT_EQ(mat.baseColor, 0u);
+    EXPECT_EQ(mat.density, 0);
+}
+
+// -- setRule + lookup round-trip ----------------------------------------------
+
+TEST(ProjectionRuleTableTest, SetRuleLookupRoundTrip) {
+    ProjectionRuleTable table;
+
+    ProjectedMaterial rule;
+    rule.displayName = "TestMaterial";
+    rule.baseColor = 0xFFAA5500;
+    rule.soundCategory = 3;
+    rule.semanticPriority = 10;
+    rule.moveType = MoveType::Powder;
+    rule.density = 130;
+
+    table.setRule(5, Phase::Powder, rule);
+
+    const auto& result = table.lookup(5, Phase::Powder);
+    EXPECT_EQ(result.displayName, "TestMaterial");
+    EXPECT_EQ(result.baseColor, 0xFFAA5500u);
+    EXPECT_EQ(result.soundCategory, 3);
+    EXPECT_EQ(result.semanticPriority, 10);
+    EXPECT_EQ(result.moveType, MoveType::Powder);
+    EXPECT_EQ(result.density, 130);
+}
+
+// -- Multiple phases for same essenceIdx --------------------------------------
+
+TEST(ProjectionRuleTableTest, IndependentPhaseEntries) {
+    ProjectionRuleTable table;
+
+    ProjectedMaterial solid;
+    solid.baseColor = 0xFF000001;
+    solid.moveType = MoveType::Static;
+    table.setRule(1, Phase::Solid, solid);
+
+    ProjectedMaterial liquid;
+    liquid.baseColor = 0xFF000002;
+    liquid.moveType = MoveType::Liquid;
+    table.setRule(1, Phase::Liquid, liquid);
+
+    EXPECT_EQ(table.lookup(1, Phase::Solid).baseColor, 0xFF000001u);
+    EXPECT_EQ(table.lookup(1, Phase::Liquid).baseColor, 0xFF000002u);
+    // Unset phases for the same essenceIdx remain default
+    EXPECT_EQ(table.lookup(1, Phase::Empty).baseColor, 0u);
+    EXPECT_EQ(table.lookup(1, Phase::Powder).baseColor, 0u);
+    EXPECT_EQ(table.lookup(1, Phase::Gas).baseColor, 0u);
+}
+
+// -- Boundary values ----------------------------------------------------------
+
+TEST(ProjectionRuleTableTest, EssenceIdxZeroAir) {
+    ProjectionRuleTable table;
+
+    ProjectedMaterial air;
+    air.baseColor = 0x00000000;
+    air.moveType = MoveType::Static;
+    table.setRule(0, Phase::Empty, air);
+
+    const auto& result = table.lookup(0, Phase::Empty);
+    EXPECT_EQ(result.baseColor, 0u);
+}
+
+TEST(ProjectionRuleTableTest, EssenceIdxMax) {
+    ProjectionRuleTable table;
+
+    ProjectedMaterial rare;
+    rare.baseColor = 0xFFFF00FF;
+    rare.density = 255;
+    table.setRule(255, Phase::Gas, rare);
+
+    const auto& result = table.lookup(255, Phase::Gas);
+    EXPECT_EQ(result.baseColor, 0xFFFF00FFu);
+    EXPECT_EQ(result.density, 255);
+}
+
+// -- Phase enum coverage ------------------------------------------------------
+
+TEST(ProjectionRuleTableTest, AllPhasesProduceValidIndices) {
+    ProjectionRuleTable table;
+    const Phase phases[] = {Phase::Empty, Phase::Solid, Phase::Powder, Phase::Liquid, Phase::Gas};
+
+    for (auto p : phases) {
+        ProjectedMaterial mat;
+        mat.baseColor = static_cast<uint32_t>(p) + 1;
+        table.setRule(10, p, mat);
+    }
+
+    for (auto p : phases) {
+        EXPECT_EQ(table.lookup(10, p).baseColor, static_cast<uint32_t>(p) + 1);
+    }
+}
+
+// -- populateFromRegistry -----------------------------------------------------
+
+TEST(ProjectionRuleTableTest, PopulateFromRegistryStone) {
+    MaterialRegistry registry;
+    ProjectionRuleTable table;
+    table.populateFromRegistry(registry);
+
+    // Stone: MaterialId=1, MoveType::Static -> Phase::Solid
+    const auto& stone = table.lookup(static_cast<uint8_t>(material_ids::STONE), Phase::Solid);
+    EXPECT_EQ(stone.baseColor, 0xFF808080u);
+    EXPECT_EQ(stone.moveType, MoveType::Static);
+    EXPECT_EQ(stone.density, 200);
+}
+
+TEST(ProjectionRuleTableTest, PopulateFromRegistrySand) {
+    MaterialRegistry registry;
+    ProjectionRuleTable table;
+    table.populateFromRegistry(registry);
+
+    // Sand: MaterialId=3, MoveType::Powder -> Phase::Powder
+    const auto& sand = table.lookup(static_cast<uint8_t>(material_ids::SAND), Phase::Powder);
+    EXPECT_EQ(sand.baseColor, 0xFFC2B280u);
+    EXPECT_EQ(sand.moveType, MoveType::Powder);
+    EXPECT_EQ(sand.density, 130);
+}
+
+TEST(ProjectionRuleTableTest, PopulateFromRegistryWater) {
+    MaterialRegistry registry;
+    ProjectionRuleTable table;
+    table.populateFromRegistry(registry);
+
+    // Water: MaterialId=4, MoveType::Liquid -> Phase::Liquid
+    const auto& water = table.lookup(static_cast<uint8_t>(material_ids::WATER), Phase::Liquid);
+    EXPECT_EQ(water.baseColor, 0xFF4040C0u);
+    EXPECT_EQ(water.moveType, MoveType::Liquid);
+    EXPECT_EQ(water.density, 100);
+}
+
+TEST(ProjectionRuleTableTest, PopulateFromRegistryAir) {
+    MaterialRegistry registry;
+    ProjectionRuleTable table;
+    table.populateFromRegistry(registry);
+
+    // Air: MaterialId=0, AIR -> Phase::Empty
+    const auto& air = table.lookup(0, Phase::Empty);
+    EXPECT_EQ(air.baseColor, 0x00000000u);
+    EXPECT_EQ(air.moveType, MoveType::Static);
+    EXPECT_EQ(air.density, 0);
+}
+
+// -- Overwrite after populate -------------------------------------------------
+
+TEST(ProjectionRuleTableTest, SetRuleOverridesPopulated) {
+    MaterialRegistry registry;
+    ProjectionRuleTable table;
+    table.populateFromRegistry(registry);
+
+    ProjectedMaterial custom;
+    custom.baseColor = 0xFFDEAD00;
+    custom.density = 42;
+    table.setRule(static_cast<uint8_t>(material_ids::STONE), Phase::Solid, custom);
+
+    const auto& result = table.lookup(static_cast<uint8_t>(material_ids::STONE), Phase::Solid);
+    EXPECT_EQ(result.baseColor, 0xFFDEAD00u);
+    EXPECT_EQ(result.density, 42);
+}


### PR DESCRIPTION
## Summary
- Define `MatterState` v1 struct with Shape C layout (4 bytes: essenceIdx + displacementRank + phase/flags + spare)
- Define `Phase` enum (Empty, Solid, Powder, Liquid, Gas)
- Add `CellQuery` and `SemanticQuery` C++20 concepts constraining cell accessor interfaces
- Compile-time `static_assert` validates both `VoxelCell` and `MatterState` satisfy both concepts
- Add `ProjectionRuleTable` mapping `(essenceIdx, phase)` to `ProjectedMaterial` struct
- `populateFromRegistry()` bridges existing `MaterialRegistry` data for migration compatibility

## Changes
- New `include/recurse/simulation/MatterState.hh`: struct, Phase enum, bit-packing accessors
- New `include/recurse/simulation/ProjectionRuleTable.hh` + `src/recurse/simulation/ProjectionRuleTable.cc`: flat-array projection table
- Updated `CellAccessors.hh`: MatterState overloads for `isOccupied`/`isEmpty`/`cellPhase`/`canDisplace`, concept definitions
- 28 new unit tests (16 MatterState + 12 ProjectionRuleTable)

## Test plan
- [x] `mise run build` passes
- [x] `mise run test` passes (2227/2230, 3 expected Vulkan skips)
- [x] No behavior change to existing code paths
- [x] Visual verification: terrain renders identically

Part of Wave 3 of the MatterState migration (Track B: contract design).

Closes #65, #66
Resolves #77