### PR TITLE
feat(simulation): swap VoxelCell to essence-first MatterState layout

### DIFF
--- a/include/recurse/character/VoxelInteraction.hh
+++ b/include/recurse/character/VoxelInteraction.hh
@@ -3,6 +3,7 @@
 #include "fabric/core/Event.hh"
 #include "fabric/render/Geometry.hh"
 #include "recurse/persistence/ChangeSource.hh"
+#include "recurse/simulation/MaterialRegistry.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 #include "recurse/world/FunctionContracts.hh"
@@ -89,7 +90,7 @@ struct InteractionResult {
 
 class VoxelInteraction {
   public:
-    explicit VoxelInteraction(SimulationGrid& grid);
+    VoxelInteraction(SimulationGrid& grid, const simulation::MaterialRegistry& registry);
 
     // Place voxel adjacent to hit face
     InteractionResult createMatter(const VoxelHit& hit,
@@ -112,6 +113,7 @@ class VoxelInteraction {
 
   private:
     SimulationGrid& grid_;
+    const simulation::MaterialRegistry& registry_;
 };
 
 } // namespace recurse

--- a/include/recurse/persistence/FchkCodec.hh
+++ b/include/recurse/persistence/FchkCodec.hh
@@ -9,7 +9,7 @@ namespace recurse {
 /// FCHK binary chunk format header (10 bytes).
 struct FchkHeader {
     char magic[4]{'F', 'C', 'H', 'K'};
-    uint16_t version{2};
+    uint16_t version{4};
     uint8_t dimX{32};
     uint8_t dimY{32};
     uint8_t dimZ{32};
@@ -39,17 +39,18 @@ struct FchkDeltaDecoded {
     uint16_t paletteEntryCount{0};
 };
 
-/// Shared FCHK codec. Handles v1/v2 full blobs and v3 delta blobs.
+/// Shared FCHK codec. Handles v1/v2/v4 full blobs and v3 delta blobs.
 struct FchkCodec {
-    /// Encode raw VoxelCell data into FCHK v2 blob.
+    /// Encode raw cell data into FCHK v2 blob (v4 encode added in W4-D).
     /// When paletteData is non-null and paletteEntryCount > 0, palette is appended after the
     /// voxel payload. Compression wraps bytes 10-EOF (payload + palette).
     static ChunkBlob encode(const void* cells, size_t cellsByteCount, uint8_t compression = 0, int level = 1,
                             const float* paletteData = nullptr, uint16_t paletteEntryCount = 0);
 
-    /// Decode FCHK blob (v1 or v2). Validates header, decompresses if needed.
+    /// Decode FCHK blob (v1, v2, or v4). Validates header, decompresses if needed.
     /// v1 files: returns cells only, paletteEntryCount == 0, essenceIdx bytes zeroed.
     /// v2 files: returns cells + palette section.
+    /// v4 files: MatterState layout, runtime flags cleared from phaseAndFlags byte.
     /// Throws for v3 blobs (use decodeDelta instead).
     static FchkDecoded decode(const ChunkBlob& blob);
 
@@ -66,7 +67,7 @@ struct FchkCodec {
     /// Check if a blob is a v3 delta format (without full decode).
     static bool isDelta(const ChunkBlob& blob);
 
-    /// Decode any FCHK blob (v1/v2/v3). For v3 deltas, applies diff entries
+    /// Decode any FCHK blob (v1/v2/v3/v4). For v3 deltas, applies diff entries
     /// to refCells to produce full cell data. refCells must point to
     /// K_CHUNK_VOLUME * sizeof(VoxelCell) bytes when blob is v3.
     /// For v1/v2, refCells is ignored. Throws if blob is v3 and refCells is null.

--- a/include/recurse/simulation/CellAccessors.hh
+++ b/include/recurse/simulation/CellAccessors.hh
@@ -2,36 +2,47 @@
 
 #include "recurse/simulation/MaterialRegistry.hh"
 #include "recurse/simulation/MatterState.hh"
+#include "recurse/simulation/ProjectionRuleTable.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 
 #include <concepts>
 
 namespace recurse::simulation {
 
-/// True when the cell contains a non-AIR material.
+/// True when the cell is occupied (not Empty phase).
 constexpr bool isOccupied(VoxelCell cell) {
-    return cell.materialId != material_ids::AIR;
+    return cell.phase() != Phase::Empty;
 }
 
-/// True when the cell is AIR (empty).
+/// True when the cell is empty.
 constexpr bool isEmpty(VoxelCell cell) {
-    return cell.materialId == material_ids::AIR;
+    return cell.phase() == Phase::Empty;
 }
 
-/// Returns the cell move phase from the material registry.
-inline MoveType cellPhase(const MaterialRegistry& registry, VoxelCell cell) {
-    return registry.get(cell.materialId).moveType;
+/// Returns the cell phase as MoveType. Registry parameter accepted for concept
+/// satisfaction but unused; VoxelCell carries its phase directly.
+inline MoveType cellPhase(const MaterialRegistry& /*registry*/, VoxelCell cell) {
+    switch (cell.phase()) {
+        case Phase::Solid:
+            return MoveType::Static;
+        case Phase::Powder:
+            return MoveType::Powder;
+        case Phase::Liquid:
+            return MoveType::Liquid;
+        case Phase::Gas:
+            return MoveType::Gas;
+        default:
+            return MoveType::Static;
+    }
 }
 
-/// True when mover can displace target (empty, non-static, or lower density).
-inline bool canDisplace(const MaterialRegistry& registry, VoxelCell mover, VoxelCell target) {
+/// Displacement check for VoxelCell. Uses displacementRank directly.
+inline bool canDisplace(const MaterialRegistry& /*registry*/, VoxelCell mover, VoxelCell target) {
     if (isEmpty(target))
         return true;
-    const auto& targetDef = registry.get(target.materialId);
-    if (targetDef.moveType == MoveType::Static)
+    if (target.phase() == Phase::Solid)
         return false;
-    const auto& moverDef = registry.get(mover.materialId);
-    return moverDef.density > targetDef.density;
+    return mover.displacementRank > target.displacementRank;
 }
 
 // -- MatterState overloads --------------------------------------------------
@@ -72,6 +83,73 @@ inline bool canDisplace(const MaterialRegistry& /*registry*/, MatterState mover,
     return mover.displacementRank > target.displacementRank;
 }
 
+// -- Cell factory functions ---------------------------------------------------
+
+/// Derive Phase from MoveType. Used during MaterialId -> MatterState construction.
+constexpr Phase phaseFromMoveType(MoveType mt) {
+    switch (mt) {
+        case MoveType::Static:
+            return Phase::Solid;
+        case MoveType::Powder:
+            return Phase::Powder;
+        case MoveType::Liquid:
+            return Phase::Liquid;
+        case MoveType::Gas:
+            return Phase::Gas;
+        default:
+            return Phase::Solid;
+    }
+}
+
+/// Construct a cell from raw fields.
+constexpr VoxelCell makeCell(uint8_t essenceIdx, Phase phase, uint8_t displacementRank = 0, uint8_t flags = 0) {
+    VoxelCell cell;
+    cell.essenceIdx = essenceIdx;
+    cell.displacementRank = displacementRank;
+    cell.setPhase(phase);
+    cell.setFlags(flags);
+    return cell;
+}
+
+/// Construct an empty (air) cell.
+constexpr VoxelCell emptyCell() {
+    return VoxelCell{};
+}
+
+/// Construct a VoxelCell from a MaterialId using the MaterialRegistry.
+/// During migration: essenceIdx == materialId (1:1 mapping).
+inline VoxelCell makeCellFromMaterial(MaterialId id, const MaterialRegistry& registry, uint8_t flags = 0) {
+    VoxelCell cell;
+    cell.essenceIdx = static_cast<uint8_t>(id);
+    const auto& def = registry.get(id);
+    cell.displacementRank = def.density;
+    cell.setPhase(id == material_ids::AIR ? Phase::Empty : phaseFromMoveType(def.moveType));
+    cell.setFlags(flags);
+    return cell;
+}
+
+/// Migration helper: construct a VoxelCell from a MaterialId using known
+/// material properties. Avoids requiring a MaterialRegistry instance.
+/// Only valid during migration when essenceIdx == materialId.
+inline VoxelCell cellForMaterial(MaterialId id) {
+    switch (id) {
+        case material_ids::AIR:
+            return VoxelCell{};
+        case material_ids::STONE:
+            return makeCell(1, Phase::Solid, 200);
+        case material_ids::DIRT:
+            return makeCell(2, Phase::Solid, 150);
+        case material_ids::SAND:
+            return makeCell(3, Phase::Powder, 130);
+        case material_ids::WATER:
+            return makeCell(4, Phase::Liquid, 100);
+        case material_ids::GRAVEL:
+            return makeCell(5, Phase::Powder, 170);
+        default:
+            return makeCell(static_cast<uint8_t>(id), Phase::Solid, 128);
+    }
+}
+
 // -- Cell concepts ----------------------------------------------------------
 
 /// A cell type that supports occupancy queries without external context.
@@ -95,11 +173,10 @@ static_assert(SemanticQuery<MatterState>, "MatterState must satisfy SemanticQuer
 
 // ---------------------------------------------------------------------------
 
-/// Extract the raw material id from a cell. Quarantines direct field access
-/// so the LOD and debug paths route through a single point that changes
-/// when Wave 4 swaps the cell layout.
+/// Extract the raw material id from a cell. During migration essenceIdx maps
+/// 1:1 to MaterialId. This is the single quarantine point for the mapping.
 constexpr MaterialId cellMaterialId(VoxelCell cell) {
-    return cell.materialId;
+    return static_cast<MaterialId>(cell.essenceIdx);
 }
 
 /// Semantic priority for LOD material reduction. Higher values win tiebreaks
@@ -131,12 +208,41 @@ inline constexpr MergeKey K_MERGE_KEY_EMPTY = static_cast<MergeKey>(material_ids
 
 /// Extract the merge key from a cell for the greedy mesher mask array.
 inline MergeKey mergeKey(VoxelCell cell) {
-    return cell.materialId;
+    return static_cast<MergeKey>(cell.essenceIdx);
 }
 
 /// True when two adjacent face slots can be merged into a single greedy quad.
 inline bool canMergeQuads(MergeKey a, MergeKey b) {
     return a == b;
+}
+
+// -- Projection-aware accessors (MatterState) --------------------------------
+
+/// Derive MaterialId from MatterState during migration.
+/// Uses essenceIdx directly (1:1 mapping with MaterialId during migration).
+constexpr MaterialId cellMaterialId(MatterState cell) {
+    return static_cast<MaterialId>(cell.essenceIdx);
+}
+
+/// Merge key for MatterState. Uses essenceIdx as visual identity proxy.
+inline MergeKey mergeKey(MatterState cell) {
+    return static_cast<MergeKey>(cell.essenceIdx);
+}
+
+/// Semantic priority for LOD reduction from MatterState.
+/// Delegates to the existing materialId-based function via projection.
+inline int materialSemanticPriority(MatterState cell) {
+    return materialSemanticPriority(static_cast<uint16_t>(cell.essenceIdx));
+}
+
+/// Derive MaterialId from MatterState via ProjectionRuleTable.
+/// Future-proof: uses table lookup instead of direct essenceIdx cast.
+/// During migration this returns the same result as the non-table version.
+inline MaterialId cellMaterialId(const ProjectionRuleTable& /*table*/, MatterState cell) {
+    // During migration: table.lookup maps essenceIdx -> ProjectedMaterial
+    // which has baseColor/moveType/density but not materialId directly.
+    // For now essenceIdx IS the materialId.
+    return static_cast<MaterialId>(cell.essenceIdx);
 }
 
 } // namespace recurse::simulation

--- a/include/recurse/simulation/EssenceAssigner.hh
+++ b/include/recurse/simulation/EssenceAssigner.hh
@@ -10,9 +10,10 @@ namespace recurse::simulation {
 
 class MaterialRegistry;
 
-/// Assign essenceIdx to all non-AIR voxels in a chunk buffer.
+/// Assign essence palette indices to all non-AIR voxels in a chunk buffer.
 /// Looks up each material's baseEssence, applies small spatial hash noise,
-/// and writes the quantized palette index into cell.essenceIdx.
+/// and writes the quantized palette index into cell.spare (NOT essenceIdx,
+/// which carries material identity during the MatterState migration).
 void assignEssence(VoxelCell* buffer, int cx, int cy, int cz, const MaterialRegistry& materials,
                    recurse::EssencePalette& palette, int seed);
 

--- a/include/recurse/simulation/MatterState.hh
+++ b/include/recurse/simulation/MatterState.hh
@@ -1,18 +1,8 @@
 #pragma once
 
-#include <cstdint>
+#include "recurse/simulation/VoxelMaterial.hh"
 
 namespace recurse::simulation {
-
-/// Broad matter mode for a voxel cell.
-/// Values 5-7 reserved for future use (Growth, Unstable, etc.).
-enum class Phase : uint8_t {
-    Empty = 0,
-    Solid = 1,
-    Powder = 2,
-    Liquid = 3,
-    Gas = 4
-};
 
 /// MatterState v1: 4-byte cell layout for essence-first world authority.
 /// Shape C: essenceIdx(8b) + displacementRank(8b) + phase(3b) + flags(5b) + spare(8b).

--- a/include/recurse/simulation/VoxelMaterial.hh
+++ b/include/recurse/simulation/VoxelMaterial.hh
@@ -17,6 +17,16 @@ inline constexpr MaterialId GRAVEL = 5;
 inline constexpr MaterialId COUNT = 6;
 } // namespace material_ids
 
+/// Broad matter mode for a voxel cell.
+/// Values 5-7 reserved for future use (Growth, Unstable, etc.).
+enum class Phase : uint8_t {
+    Empty = 0,
+    Solid = 1,
+    Powder = 2,
+    Liquid = 3,
+    Gas = 4
+};
+
 enum class MoveType : uint8_t {
     Static = 0, // Stone, Dirt -- does not move
     Powder = 1, // Sand, Gravel -- falls, cascades diagonally
@@ -26,16 +36,27 @@ enum class MoveType : uint8_t {
 
 namespace voxel_flags {
 inline constexpr uint8_t NONE = 0;
-inline constexpr uint8_t UPDATED = 1 << 0;   // Modified this epoch
-inline constexpr uint8_t FREE_FALL = 1 << 1; // In free-fall (optimization)
-// Bits 2-7 reserved
+inline constexpr uint8_t UPDATED = 1 << 0;   // Bit 0 of 5-bit flags field
+inline constexpr uint8_t FREE_FALL = 1 << 1; // Bit 1 of 5-bit flags field
+// Bits 2-4 reserved
 } // namespace voxel_flags
 
 /// 4-byte voxel cell. Fits 32768 cells per 32^3 chunk = 128 KB.
+/// Post Wave-4: essence-first layout matching MatterState Shape C.
 struct VoxelCell {
-    MaterialId materialId{material_ids::AIR}; // 2 bytes
-    uint8_t essenceIdx{0};                    ///< Palette index into per-chunk EssencePalette (0-255).
-    uint8_t flags{voxel_flags::NONE};         // 1 byte
+    uint8_t essenceIdx{0};       ///< Palette index into per-chunk EssencePalette.
+    uint8_t displacementRank{0}; ///< CA displacement ordering (0-255).
+    uint8_t phaseAndFlags{0};    ///< Low 3 bits = Phase, high 5 bits = flags.
+    uint8_t spare{0};            ///< Reserved, must be 0 in v1.
+
+    constexpr Phase phase() const { return static_cast<Phase>(phaseAndFlags & 0x07); }
+    constexpr void setPhase(Phase p) {
+        phaseAndFlags = static_cast<uint8_t>((phaseAndFlags & 0xF8) | (static_cast<uint8_t>(p) & 0x07));
+    }
+    constexpr uint8_t flags() const { return (phaseAndFlags >> 3) & 0x1F; }
+    constexpr void setFlags(uint8_t f) {
+        phaseAndFlags = static_cast<uint8_t>((phaseAndFlags & 0x07) | ((f & 0x1F) << 3));
+    }
 };
 static_assert(sizeof(VoxelCell) == 4, "VoxelCell must be exactly 4 bytes");
 

--- a/include/recurse/simulation/VoxelMaterial.hh
+++ b/include/recurse/simulation/VoxelMaterial.hh
@@ -44,7 +44,10 @@ inline constexpr uint8_t FREE_FALL = 1 << 1; // Bit 1 of 5-bit flags field
 /// 4-byte voxel cell. Fits 32768 cells per 32^3 chunk = 128 KB.
 /// Post Wave-4: essence-first layout matching MatterState Shape C.
 struct VoxelCell {
-    uint8_t essenceIdx{0};       ///< Palette index into per-chunk EssencePalette.
+    /// Material/essence identity index. During migration, holds MaterialId directly
+    /// (cellMaterialId() casts this to MaterialId). Will become a true essence
+    /// palette index when the essenceIdx === materialId invariant is broken.
+    uint8_t essenceIdx{0};
     uint8_t displacementRank{0}; ///< CA displacement ordering (0-255).
     uint8_t phaseAndFlags{0};    ///< Low 3 bits = Phase, high 5 bits = flags.
     uint8_t spare{0};            ///< Reserved, must be 0 in v1.

--- a/include/recurse/simulation/VoxelSemanticView.hh
+++ b/include/recurse/simulation/VoxelSemanticView.hh
@@ -148,6 +148,14 @@ class MaterialSemanticRegistry {
     }
 
     /// Resolve semantics for a voxel cell and optional essence palette.
+    //
+    // Migration contract: cell.essenceIdx holds materialId identity (used by
+    // cellMaterialId() and ProjectionRuleTable). cell.spare holds the palette
+    // index written by EssenceAssigner. resolve() reads cell.essenceIdx as
+    // a palette key, which during migration equals materialId. When no palette
+    // is loaded, resolve() falls back to intrinsic essence derivation from
+    // materialId, which produces the same result. This dual-path is intentional
+    // and collapses when the essenceIdx === materialId invariant breaks.
     ResolvedVoxelSemantics resolve(const VoxelCell& cell, const recurse::EssencePalette* palette = nullptr) const {
         ResolvedVoxelSemantics result{};
         result.material = view(cellMaterialId(cell));

--- a/include/recurse/simulation/VoxelSemanticView.hh
+++ b/include/recurse/simulation/VoxelSemanticView.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "recurse/components/EssenceTypes.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/MaterialRegistry.hh"
 #include "recurse/world/EssencePalette.hh"
 
@@ -149,7 +150,7 @@ class MaterialSemanticRegistry {
     /// Resolve semantics for a voxel cell and optional essence palette.
     ResolvedVoxelSemantics resolve(const VoxelCell& cell, const recurse::EssencePalette* palette = nullptr) const {
         ResolvedVoxelSemantics result{};
-        result.material = view(cell.materialId);
+        result.material = view(cellMaterialId(cell));
         result.sampledEssence.index = cell.essenceIdx;
         result.sampledEssence.hasPalette = (palette != nullptr);
         if (palette != nullptr && cell.essenceIdx < palette->paletteSize()) {

--- a/include/recurse/simulation/VoxelSimulationSystem.hh
+++ b/include/recurse/simulation/VoxelSimulationSystem.hh
@@ -6,6 +6,7 @@
 #include "recurse/simulation/FallingSandSystem.hh"
 #include "recurse/simulation/GhostCells.hh"
 #include "recurse/simulation/MaterialRegistry.hh"
+#include "recurse/simulation/ProjectionRuleTable.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include <bit>
 #include <cstdint>
@@ -43,6 +44,8 @@ class VoxelSimulationSystem {
     const SimulationGrid& grid() const;
     MaterialRegistry& materials();
     const MaterialRegistry& materials() const;
+    ProjectionRuleTable& projectionTable();
+    const ProjectionRuleTable& projectionTable() const;
     ChunkActivityTracker& activityTracker();
     const ChunkActivityTracker& activityTracker() const;
     uint64_t frameIndex() const;
@@ -61,6 +64,7 @@ class VoxelSimulationSystem {
 
   private:
     MaterialRegistry registry_;
+    ProjectionRuleTable projectionTable_;
     SimulationGrid grid_;
     ChunkActivityTracker tracker_;
     GhostCellManager ghosts_;

--- a/src/recurse/audio/MaterialSounds.cc
+++ b/src/recurse/audio/MaterialSounds.cc
@@ -1,5 +1,6 @@
 #include "recurse/audio/MaterialSounds.hh"
 
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 #include "recurse/world/VoxelRaycast.hh"
@@ -104,7 +105,7 @@ MaterialType MaterialSounds::detectSurfaceBelow(const recurse::simulation::Simul
 
     auto cell = grid.readCell(hit->x, hit->y, hit->z);
     using namespace recurse::simulation;
-    switch (cell.materialId) {
+    switch (cellMaterialId(cell)) {
         case material_ids::STONE:
             return MaterialType::Stone;
         case material_ids::DIRT:

--- a/src/recurse/character/VoxelInteraction.cc
+++ b/src/recurse/character/VoxelInteraction.cc
@@ -1,4 +1,5 @@
 #include "recurse/character/VoxelInteraction.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/VoxelConstants.hh"
 
 using recurse::simulation::K_CHUNK_SHIFT;
@@ -13,13 +14,14 @@ InteractionResult makeInteractionResult(int x, int y, int z, VoxelCell newCell, 
 
 } // namespace
 
-VoxelInteraction::VoxelInteraction(SimulationGrid& grid) : grid_(grid) {}
+VoxelInteraction::VoxelInteraction(SimulationGrid& grid, const simulation::MaterialRegistry& registry)
+    : grid_(grid), registry_(registry) {}
 
 InteractionResult VoxelInteraction::createMatter(const VoxelHit& hit, MaterialId materialId) {
     int x = hit.x + hit.nx;
     int y = hit.y + hit.ny;
     int z = hit.z + hit.nz;
-    VoxelCell newCell{materialId, 0, recurse::simulation::voxel_flags::UPDATED};
+    VoxelCell newCell = simulation::makeCellFromMaterial(materialId, registry_, simulation::voxel_flags::UPDATED);
     return makeInteractionResult(x, y, z, newCell, ChangeSource::Place);
 }
 
@@ -27,7 +29,8 @@ InteractionResult VoxelInteraction::destroyMatter(const VoxelHit& hit) {
     int x = hit.x;
     int y = hit.y;
     int z = hit.z;
-    VoxelCell newCell{recurse::simulation::material_ids::AIR, 0, recurse::simulation::voxel_flags::UPDATED};
+    VoxelCell newCell = simulation::emptyCell();
+    newCell.setFlags(simulation::voxel_flags::UPDATED);
     return makeInteractionResult(x, y, z, newCell, ChangeSource::Destroy);
 }
 

--- a/src/recurse/persistence/FchkCodec.cc
+++ b/src/recurse/persistence/FchkCodec.cc
@@ -1,6 +1,7 @@
 #include "recurse/persistence/FchkCodec.hh"
 
 #include "fabric/utils/ErrorHandling.hh"
+#include "recurse/simulation/VoxelMaterial.hh"
 #include <bit>
 #include <cstring>
 #include <lz4.h>
@@ -9,6 +10,71 @@
 static_assert(std::endian::native == std::endian::little, "FchkCodec assumes little-endian byte order");
 
 namespace recurse {
+
+namespace {
+
+/// Convert a single v1/v2 cell (old layout) to v4 cell (new layout) in-place.
+/// Old layout (LE): [matId_lo, matId_hi, essenceIdx, flags]
+/// New layout (LE): [essenceIdx, displacementRank, phaseAndFlags, spare]
+/// Since all materialIds < 256, matId_lo IS the materialId.
+void convertV2CellToV4(uint8_t* cell) {
+    uint8_t matIdLo = cell[0];
+    // cell[1] is matId_hi (always 0)
+    uint8_t oldEssenceIdx = cell[2];
+    // cell[3] is flags (already stripped of runtime bits)
+
+    // Derive phase and density from materialId using known constants
+    using namespace simulation;
+    uint8_t phase = 0; // Phase::Empty
+    uint8_t density = 0;
+    switch (matIdLo) {
+        case material_ids::AIR:
+            phase = 0;
+            density = 0;
+            break;
+        case material_ids::STONE:
+            phase = 1;
+            density = 200;
+            break; // Phase::Solid
+        case material_ids::DIRT:
+            phase = 1;
+            density = 150;
+            break; // Phase::Solid
+        case material_ids::SAND:
+            phase = 2;
+            density = 130;
+            break; // Phase::Powder
+        case material_ids::WATER:
+            phase = 3;
+            density = 100;
+            break; // Phase::Liquid
+        case material_ids::GRAVEL:
+            phase = 2;
+            density = 170;
+            break; // Phase::Powder
+        default:
+            phase = 1;
+            density = 128;
+            break; // Unknown: default Solid
+    }
+
+    // Write new layout
+    cell[0] = matIdLo; // essenceIdx == materialId during migration
+    cell[1] = density; // displacementRank
+    cell[2] = phase;   // phaseAndFlags (phase in low 3 bits, flags 0)
+    cell[3] = 0;       // spare
+
+    // Preserve old essenceIdx: overwrite byte 0 only if old essenceIdx was
+    // palette-assigned (non-zero and from a v2 file). For v1 files, old byte 2
+    // was temperature (already zeroed by v1 fixup before this function is called
+    // for v2 only). For v2, the essenceIdx was a palette index separate from
+    // materialId; during migration essenceIdx == materialId, so use matIdLo.
+    // The old essenceIdx (palette-based) is discarded because the palette
+    // indices in old files are not meaningful in the new layout.
+    (void)oldEssenceIdx;
+}
+
+} // namespace
 
 ChunkBlob FchkCodec::encode(const void* cells, size_t cellsByteCount, uint8_t compression, int level,
                             const float* paletteData, uint16_t paletteEntryCount) {
@@ -84,7 +150,7 @@ FchkDecoded FchkCodec::decode(const ChunkBlob& blob) {
     if (header.version == 3) {
         fabric::throwError("FCHK v3 is a delta format; use FchkCodec::decodeDelta()");
     }
-    if (header.version < 1 || header.version > 2) {
+    if (header.version < 1 || header.version > 4) {
         fabric::throwError("FCHK unsupported version: " + std::to_string(header.version));
     }
 
@@ -145,20 +211,33 @@ FchkDecoded FchkCodec::decode(const ChunkBlob& blob) {
     FchkDecoded result;
     result.cells.assign(postHeader, postHeader + cellsByteCount);
 
-    constexpr uint8_t kRuntimeFlagsMask = static_cast<uint8_t>(~(0x01 | 0x02));
-    for (size_t i = 3; i < result.cells.size(); i += 4)
-        result.cells[i] &= kRuntimeFlagsMask;
+    if (header.version == 4) {
+        // v4: runtime flags in byte 2 (phaseAndFlags), bits 3-4
+        constexpr uint8_t kRuntimeFlagsMask = static_cast<uint8_t>(~(0x08 | 0x10));
+        for (size_t i = 2; i < result.cells.size(); i += 4)
+            result.cells[i] &= kRuntimeFlagsMask;
+    } else if (header.version <= 2) {
+        // v1/v2: strip runtime flags from old layout byte 3
+        constexpr uint8_t kRuntimeFlagsMask = static_cast<uint8_t>(~(0x01 | 0x02));
+        for (size_t i = 3; i < result.cells.size(); i += 4)
+            result.cells[i] &= kRuntimeFlagsMask;
 
-    if (header.version == 1) {
-        // v1 fixup: zero out essenceIdx byte (offset 2 within each 4-byte VoxelCell).
-        // Old files have temperature=128 in that byte, which would cause OOB palette lookups.
-        for (size_t i = 2; i < result.cells.size(); i += 4) {
-            result.cells[i] = 0;
+        if (header.version == 1) {
+            // v1 fixup: zero out old essenceIdx byte (offset 2) before conversion.
+            for (size_t i = 2; i < result.cells.size(); i += 4)
+                result.cells[i] = 0;
         }
-        return result;
+
+        // Convert old v1/v2 layout to v4 layout in-place
+        for (size_t i = 0; i < result.cells.size(); i += 4)
+            convertV2CellToV4(&result.cells[i]);
+
+        // v1: no palette section, return early
+        if (header.version == 1)
+            return result;
     }
 
-    // v2: parse palette section after voxel payload
+    // v2/v4: parse palette section after voxel payload
     const size_t paletteSectionOffset = cellsByteCount;
     if (postHeaderSize >= paletteSectionOffset + sizeof(uint16_t)) {
         std::memcpy(&result.paletteEntryCount, postHeader + paletteSectionOffset, sizeof(uint16_t));
@@ -167,7 +246,7 @@ FchkDecoded FchkCodec::decode(const ChunkBlob& blob) {
         const size_t expectedSize = paletteSectionOffset + sizeof(uint16_t) + paletteByteCount;
 
         if (postHeaderSize < expectedSize) {
-            fabric::throwError("FCHK v2 palette section truncated");
+            fabric::throwError("FCHK palette section truncated (v" + std::to_string(header.version) + ")");
         }
 
         if (result.paletteEntryCount > 0) {
@@ -196,7 +275,9 @@ ChunkBlob FchkCodec::encodeDelta(const void* currentCells, const void* reference
     // state. Without masking, every "touched" cell produces a false diff
     // against the clean worldgen reference. The decode side already strips
     // these via kRuntimeFlagsMask.
-    constexpr uint32_t kPersistMask = 0xFC'FF'FF'FF; // clear bits 0-1 of flags byte (byte 3, LE)
+    // New VoxelCell layout: phaseAndFlags in byte 2 (LE). Runtime flags (UPDATED, FREE_FALL)
+    // occupy bits 3-4 of that byte (bits 19-20 of the uint32_t). Clear them before diffing.
+    constexpr uint32_t kPersistMask = 0xFF'E7'FF'FF;
 
     std::vector<FchkDeltaEntry> diffs;
     for (size_t i = 0; i < cellCount; ++i) {
@@ -372,11 +453,11 @@ FchkDeltaDecoded FchkCodec::decodeDelta(const ChunkBlob& blob) {
     }
     cursor += entriesBytes;
 
-    // Apply runtime flags mask to cell data
-    constexpr uint8_t kRuntimeFlagsMask = static_cast<uint8_t>(~(0x01 | 0x02));
+    // Apply runtime flags mask to cell data (v4 layout: phaseAndFlags in byte 2)
+    constexpr uint8_t kRuntimeFlagsMask = static_cast<uint8_t>(~(0x08 | 0x10));
     for (auto& e : result.entries) {
         auto* bytes = reinterpret_cast<uint8_t*>(&e.cellData);
-        bytes[3] &= kRuntimeFlagsMask;
+        bytes[2] &= kRuntimeFlagsMask;
     }
 
     // Parse palette section
@@ -413,9 +494,9 @@ FchkDecoded FchkCodec::decodeAny(const ChunkBlob& blob, const void* refCells) {
     result.cells.resize(cellsByteCount);
     std::memcpy(result.cells.data(), refCells, cellsByteCount);
 
-    // Clear runtime flags on reference cells (same mask as v2 decode)
-    constexpr uint8_t kRuntimeFlagsMask = static_cast<uint8_t>(~(0x01 | 0x02));
-    for (size_t i = 3; i < result.cells.size(); i += 4)
+    // Clear runtime flags on reference cells (v4 layout: phaseAndFlags in byte 2)
+    constexpr uint8_t kRuntimeFlagsMask = static_cast<uint8_t>(~(0x08 | 0x10));
+    for (size_t i = 2; i < result.cells.size(); i += 4)
         result.cells[i] &= kRuntimeFlagsMask;
 
     // Apply delta entries (already have runtime flags cleared from decodeDelta)

--- a/src/recurse/persistence/FchkCodec.cc
+++ b/src/recurse/persistence/FchkCodec.cc
@@ -453,7 +453,12 @@ FchkDeltaDecoded FchkCodec::decodeDelta(const ChunkBlob& blob) {
     }
     cursor += entriesBytes;
 
-    // Apply runtime flags mask to cell data (v4 layout: phaseAndFlags in byte 2)
+    // Apply runtime flags mask to cell data (v4 layout: phaseAndFlags in byte 2).
+    // Note: All v3 delta files in existence use the v4 (MatterState) cell layout
+    // because v3 delta format was introduced alongside the MatterState migration.
+    // No pre-MatterState v3 deltas exist. The v4 runtime flags mask is correct
+    // for all real v3 files. This version branching will be eliminated by the
+    // persistence format collapse (feat/persistence-collapse).
     constexpr uint8_t kRuntimeFlagsMask = static_cast<uint8_t>(~(0x08 | 0x10));
     for (auto& e : result.entries) {
         auto* bytes = reinterpret_cast<uint8_t*>(&e.cellData);

--- a/src/recurse/simulation/EssenceAssigner.cc
+++ b/src/recurse/simulation/EssenceAssigner.cc
@@ -65,7 +65,7 @@ void assignEssence(VoxelCell* buffer, int cx, int cy, int cz, const MaterialRegi
     for (int i = 0; i < K_CHUNK_VOLUME; ++i) {
         if (isEmpty(buffer[i]))
             continue;
-        auto mid = buffer[i].materialId;
+        auto mid = cellMaterialId(buffer[i]);
         bool found = false;
         for (int m = 0; m < matCount; ++m) {
             if (uniqueMats[m] == mid) {
@@ -133,7 +133,7 @@ void assignEssence(VoxelCell* buffer, int cx, int cy, int cz, const MaterialRegi
 
                 int matIdx = 0;
                 for (int m = 0; m < matCount; ++m) {
-                    if (uniqueMats[m] == cell.materialId) {
+                    if (uniqueMats[m] == cellMaterialId(cell)) {
                         matIdx = m;
                         break;
                     }
@@ -149,7 +149,7 @@ void assignEssence(VoxelCell* buffer, int cx, int cy, int cz, const MaterialRegi
                 int qw = quantStep(spatialHash(wx, wy, wz, 3, seed) * K_NOISE_AMPLITUDE);
 
                 int noiseIdx = qx + qy * K + qz * K * K + qw * K * K * K;
-                cell.essenceIdx = paletteLUT[matIdx * entriesPerMat + noiseIdx];
+                cell.spare = paletteLUT[matIdx * entriesPerMat + noiseIdx];
             }
         }
     }

--- a/src/recurse/simulation/EssenceAssigner.cc
+++ b/src/recurse/simulation/EssenceAssigner.cc
@@ -149,6 +149,11 @@ void assignEssence(VoxelCell* buffer, int cx, int cy, int cz, const MaterialRegi
                 int qw = quantStep(spatialHash(wx, wy, wz, 3, seed) * K_NOISE_AMPLITUDE);
 
                 int noiseIdx = qx + qy * K + qz * K * K + qw * K * K * K;
+                // Write palette index to cell.spare, NOT cell.essenceIdx. During
+                // migration, essenceIdx holds material identity (cellMaterialId()
+                // casts it). Overwriting it with a palette index would break material
+                // resolution for all consumers. This field split collapses when the
+                // essenceIdx === materialId invariant breaks (feat/essence-decoupling).
                 cell.spare = paletteLUT[matIdx * entriesPerMat + noiseIdx];
             }
         }

--- a/src/recurse/simulation/ProjectionRuleTable.cc
+++ b/src/recurse/simulation/ProjectionRuleTable.cc
@@ -1,6 +1,8 @@
 #include "recurse/simulation/ProjectionRuleTable.hh"
 #include "recurse/simulation/MaterialRegistry.hh"
 
+#include <algorithm>
+
 namespace recurse::simulation {
 
 ProjectionRuleTable::ProjectionRuleTable() = default;
@@ -19,10 +21,8 @@ void ProjectionRuleTable::setRule(uint8_t essenceIdx, Phase phase, const Project
 
 void ProjectionRuleTable::populateFromRegistry(const MaterialRegistry& registry) {
     // During migration, MaterialId maps 1:1 to essenceIdx for registered materials.
-    for (MaterialId id = 0; id < registry.count(); ++id) {
-        if (id >= K_MAX_ESSENCE) {
-            continue;
-        }
+    const MaterialId limit = std::min(registry.count(), static_cast<MaterialId>(K_MAX_ESSENCE));
+    for (MaterialId id = 0; id < limit; ++id) {
         const auto& def = registry.get(id);
 
         // Derive phase from MoveType (mirrors CellAccessors.hh cellPhase logic)

--- a/src/recurse/simulation/VoxelSimulationSystem.cc
+++ b/src/recurse/simulation/VoxelSimulationSystem.cc
@@ -5,7 +5,9 @@
 
 namespace recurse::simulation {
 
-VoxelSimulationSystem::VoxelSimulationSystem() : sandSystem_(registry_) {}
+VoxelSimulationSystem::VoxelSimulationSystem() : sandSystem_(registry_) {
+    projectionTable_.populateFromRegistry(registry_);
+}
 
 void VoxelSimulationSystem::tick() {
     FABRIC_ZONE_SCOPED_N("voxel_sim_tick");
@@ -187,6 +189,12 @@ MaterialRegistry& VoxelSimulationSystem::materials() {
 }
 const MaterialRegistry& VoxelSimulationSystem::materials() const {
     return registry_;
+}
+ProjectionRuleTable& VoxelSimulationSystem::projectionTable() {
+    return projectionTable_;
+}
+const ProjectionRuleTable& VoxelSimulationSystem::projectionTable() const {
+    return projectionTable_;
 }
 ChunkActivityTracker& VoxelSimulationSystem::activityTracker() {
     return tracker_;

--- a/src/recurse/systems/VoxelInteractionSystem.cc
+++ b/src/recurse/systems/VoxelInteractionSystem.cc
@@ -33,7 +33,7 @@ void VoxelInteractionSystem::doInit(fabric::AppContext& ctx) {
     camera_ = ctx.systemRegistry.get<CameraGameSystem>();
     voxelSim_ = ctx.systemRegistry.get<VoxelSimulationSystem>();
 
-    voxelInteraction_ = std::make_unique<VoxelInteraction>(voxelSim_->simulationGrid());
+    voxelInteraction_ = std::make_unique<VoxelInteraction>(voxelSim_->simulationGrid(), voxelSim_->materials());
 
     FABRIC_LOG_INFO("VoxelInteractionSystem initialized");
 }

--- a/src/recurse/world/FlatGenerator.cc
+++ b/src/recurse/world/FlatGenerator.cc
@@ -1,4 +1,5 @@
 #include "recurse/world/FlatGenerator.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 
@@ -18,22 +19,19 @@ void FlatGenerator::generate(SimulationGrid& grid, int cx, int cy, int cz) {
     }
 
     if (topY < surfaceHeight_) {
-        VoxelCell stone;
-        stone.materialId = material_ids::STONE;
+        VoxelCell stone = makeCell(static_cast<uint8_t>(material_ids::STONE), Phase::Solid, 200);
         grid.fillChunk(cx, cy, cz, stone);
         return;
     }
 
-    VoxelCell stone;
-    stone.materialId = material_ids::STONE;
+    VoxelCell stone = makeCell(static_cast<uint8_t>(material_ids::STONE), Phase::Solid, 200);
     grid.fillChunk(cx, cy, cz, stone);
 
     for (int lz = 0; lz < K_CHUNK_SIZE; ++lz) {
         for (int ly = 0; ly < K_CHUNK_SIZE; ++ly) {
             int worldY = baseY + ly;
             if (worldY == surfaceHeight_) {
-                VoxelCell dirt;
-                dirt.materialId = material_ids::DIRT;
+                VoxelCell dirt = makeCell(static_cast<uint8_t>(material_ids::DIRT), Phase::Solid, 150);
                 for (int lx = 0; lx < K_CHUNK_SIZE; ++lx) {
                     int wx = cx * K_CHUNK_SIZE + lx;
                     int wz = cz * K_CHUNK_SIZE + lz;

--- a/src/recurse/world/MinecraftNoiseGenerator.cc
+++ b/src/recurse/world/MinecraftNoiseGenerator.cc
@@ -1,4 +1,5 @@
 #include "recurse/world/MinecraftNoiseGenerator.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 #include <algorithm>
@@ -9,10 +10,33 @@
 namespace recurse {
 
 using simulation::MaterialId;
+using simulation::Phase;
 namespace material_ids = simulation::material_ids;
 using simulation::VoxelCell;
 
 namespace {
+
+/// Migration helper: construct a VoxelCell from a MaterialId using known
+/// material properties. Avoids requiring a MaterialRegistry in generators.
+VoxelCell cellForMaterial(MaterialId id) {
+    using simulation::makeCell;
+    switch (id) {
+        case material_ids::AIR:
+            return VoxelCell{};
+        case material_ids::STONE:
+            return makeCell(1, Phase::Solid, 200);
+        case material_ids::DIRT:
+            return makeCell(2, Phase::Solid, 150);
+        case material_ids::SAND:
+            return makeCell(3, Phase::Powder, 130);
+        case material_ids::WATER:
+            return makeCell(4, Phase::Liquid, 100);
+        case material_ids::GRAVEL:
+            return makeCell(5, Phase::Powder, 170);
+        default:
+            return makeCell(static_cast<uint8_t>(id), Phase::Solid, 128);
+    }
+}
 
 constexpr float K_FILLED_DENSITY_THRESHOLD = 0.0f;
 constexpr uint32_t K_TERRAIN_RULE_VERSION = 3;
@@ -241,8 +265,7 @@ void MinecraftNoiseGenerator::generateToBuffer(VoxelCell* buffer, int cx, int cy
                     continue;
                 }
 
-                VoxelCell cell;
-                cell.materialId = materialId;
+                VoxelCell cell = cellForMaterial(materialId);
                 int idx = lx + ly * K_SIZE + lz * K_SIZE * K_SIZE;
                 buffer[idx] = cell;
             }

--- a/src/recurse/world/MinecraftNoiseGenerator.cc
+++ b/src/recurse/world/MinecraftNoiseGenerator.cc
@@ -12,31 +12,10 @@ namespace recurse {
 using simulation::MaterialId;
 using simulation::Phase;
 namespace material_ids = simulation::material_ids;
+using simulation::cellForMaterial;
 using simulation::VoxelCell;
 
 namespace {
-
-/// Migration helper: construct a VoxelCell from a MaterialId using known
-/// material properties. Avoids requiring a MaterialRegistry in generators.
-VoxelCell cellForMaterial(MaterialId id) {
-    using simulation::makeCell;
-    switch (id) {
-        case material_ids::AIR:
-            return VoxelCell{};
-        case material_ids::STONE:
-            return makeCell(1, Phase::Solid, 200);
-        case material_ids::DIRT:
-            return makeCell(2, Phase::Solid, 150);
-        case material_ids::SAND:
-            return makeCell(3, Phase::Powder, 130);
-        case material_ids::WATER:
-            return makeCell(4, Phase::Liquid, 100);
-        case material_ids::GRAVEL:
-            return makeCell(5, Phase::Powder, 170);
-        default:
-            return makeCell(static_cast<uint8_t>(id), Phase::Solid, 128);
-    }
-}
 
 constexpr float K_FILLED_DENSITY_THRESHOLD = 0.0f;
 constexpr uint32_t K_TERRAIN_RULE_VERSION = 3;

--- a/src/recurse/world/TestWorldGenerator.cc
+++ b/src/recurse/world/TestWorldGenerator.cc
@@ -1,6 +1,7 @@
 #include "recurse/world/TestWorldGenerator.hh"
 
 #include "fabric/world/ChunkedGrid.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 
@@ -24,20 +25,21 @@ void FlatWorldGenerator::generate(recurse::simulation::SimulationGrid& grid, int
 
     // Entirely below ground: fill with stone sentinel (no allocation)
     if (topY < groundLevel_) {
-        grid.fillChunk(cx, cy, cz, VoxelCell{material_ids::STONE});
+        grid.fillChunk(cx, cy, cz, makeCell(static_cast<uint8_t>(material_ids::STONE), Phase::Solid, 200));
         return;
     }
 
     // Mixed chunk: per-voxel
     int baseX = cx * K_CHUNK_SIZE;
     int baseZ = cz * K_CHUNK_SIZE;
+    VoxelCell stone = makeCell(static_cast<uint8_t>(material_ids::STONE), Phase::Solid, 200);
     for (int lz = 0; lz < K_CHUNK_SIZE; ++lz) {
         for (int ly = 0; ly < K_CHUNK_SIZE; ++ly) {
             int wy = baseY + ly;
             if (wy >= groundLevel_)
                 break;
             for (int lx = 0; lx < K_CHUNK_SIZE; ++lx) {
-                grid.writeCell(baseX + lx, wy, baseZ + lz, VoxelCell{material_ids::STONE});
+                grid.writeCell(baseX + lx, wy, baseZ + lz, stone);
             }
         }
     }
@@ -73,21 +75,23 @@ void LayeredWorldGenerator::generate(recurse::simulation::SimulationGrid& grid, 
 
     // Entirely below stone level: all stone
     if (topY < stoneLevel_) {
-        grid.fillChunk(cx, cy, cz, VoxelCell{material_ids::STONE});
+        grid.fillChunk(cx, cy, cz, makeCell(static_cast<uint8_t>(material_ids::STONE), Phase::Solid, 200));
         return;
     }
 
     // Mixed or sand-only chunk: per-voxel
     int baseX = cx * K_CHUNK_SIZE;
     int baseZ = cz * K_CHUNK_SIZE;
+    VoxelCell stone = makeCell(static_cast<uint8_t>(material_ids::STONE), Phase::Solid, 200);
+    VoxelCell sand = makeCell(static_cast<uint8_t>(material_ids::SAND), Phase::Powder, 130);
     for (int lz = 0; lz < K_CHUNK_SIZE; ++lz) {
         for (int ly = 0; ly < K_CHUNK_SIZE; ++ly) {
             int wy = baseY + ly;
             if (wy >= totalGround)
                 break;
-            MaterialId mat = (wy < stoneLevel_) ? material_ids::STONE : material_ids::SAND;
+            VoxelCell mat = (wy < stoneLevel_) ? stone : sand;
             for (int lx = 0; lx < K_CHUNK_SIZE; ++lx) {
-                grid.writeCell(baseX + lx, wy, baseZ + lz, VoxelCell{mat});
+                grid.writeCell(baseX + lx, wy, baseZ + lz, mat);
             }
         }
     }

--- a/tests/unit/core/AudioSystemTest.cc
+++ b/tests/unit/core/AudioSystemTest.cc
@@ -1,5 +1,6 @@
 #include "recurse/audio/AudioSystem.hh"
 #include "recurse/audio/ReverbZone.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 
@@ -7,6 +8,7 @@
 
 using namespace fabric;
 using namespace recurse;
+using recurse::simulation::cellForMaterial;
 
 class AudioSystemTest : public ::testing::Test {
   protected:
@@ -212,7 +214,7 @@ TEST_F(AudioSystemTest, ComputeOcclusionBlockedPath) {
     SimulationGrid grid;
     for (int y = 0; y < 10; ++y)
         for (int z = 0; z < 10; ++z)
-            grid.writeCellImmediate(5, y, z, VoxelCell{material_ids::STONE, 0, 0});
+            grid.writeCellImmediate(5, y, z, cellForMaterial(material_ids::STONE));
     audio.setSimulationGrid(&grid);
     Vec3f source(2.0f, 5.0f, 5.0f);
     Vec3f listener(8.0f, 5.0f, 5.0f);
@@ -227,7 +229,7 @@ TEST_F(AudioSystemTest, ComputeOcclusionFullyBlocked) {
     for (int x = 2; x <= 9; ++x)
         for (int y = 0; y < 10; ++y)
             for (int z = 0; z < 10; ++z)
-                grid.writeCellImmediate(x, y, z, VoxelCell{material_ids::STONE, 0, 0});
+                grid.writeCellImmediate(x, y, z, cellForMaterial(material_ids::STONE));
     audio.setSimulationGrid(&grid);
     Vec3f source(0.0f, 5.0f, 5.0f);
     Vec3f listener(12.0f, 5.0f, 5.0f);
@@ -251,7 +253,7 @@ TEST_F(AudioSystemTest, OcclusionWithSolidVoxels) {
     SimulationGrid grid;
     for (int y = 0; y < 10; ++y)
         for (int z = 0; z < 10; ++z)
-            grid.writeCellImmediate(5, y, z, VoxelCell{material_ids::STONE, 0, 0});
+            grid.writeCellImmediate(5, y, z, cellForMaterial(material_ids::STONE));
     audio.setSimulationGrid(&grid);
     Vec3f source(2.0f, 5.0f, 5.0f);
     Vec3f listener(8.0f, 5.0f, 5.0f);
@@ -265,7 +267,7 @@ TEST_F(AudioSystemTest, UpdateAppliesOcclusion) {
     SimulationGrid grid;
     for (int y = 0; y < 10; ++y)
         for (int z = 0; z < 10; ++z)
-            grid.writeCellImmediate(5, y, z, VoxelCell{material_ids::STONE, 0, 0});
+            grid.writeCellImmediate(5, y, z, cellForMaterial(material_ids::STONE));
     audio.setSimulationGrid(&grid);
     audio.setOcclusionEnabled(true);
     audio.setListenerPosition(Vec3f(8.0f, 5.0f, 5.0f));

--- a/tests/unit/core/CollisionBudgetTest.cc
+++ b/tests/unit/core/CollisionBudgetTest.cc
@@ -9,6 +9,7 @@
 #include "fabric/platform/ConfigManager.hh"
 #include "fabric/resource/AssetRegistry.hh"
 #include "fabric/resource/ResourceHub.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkRegistry.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
@@ -16,6 +17,7 @@
 #include <gtest/gtest.h>
 
 using namespace recurse::systems;
+using recurse::simulation::cellForMaterial;
 using recurse::simulation::ChunkSlotState;
 using recurse::simulation::SimulationGrid;
 using recurse::simulation::VoxelCell;
@@ -72,7 +74,7 @@ class CollisionBudgetTest : public ::testing::Test {
         auto absent = addChunkRef(reg, cx, cy, cz);
         auto generating = transition<Absent, Generating>(absent, reg);
         grid.materializeChunk(cx, cy, cz);
-        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, VoxelCell{STONE});
+        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, cellForMaterial(STONE));
         grid.syncChunkBuffers(cx, cy, cz);
         transition<Generating, Active>(generating, reg);
     }

--- a/tests/unit/core/CollisionRadiusTest.cc
+++ b/tests/unit/core/CollisionRadiusTest.cc
@@ -9,6 +9,7 @@
 #include "fabric/platform/ConfigManager.hh"
 #include "fabric/resource/AssetRegistry.hh"
 #include "fabric/resource/ResourceHub.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkRegistry.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
@@ -16,6 +17,7 @@
 #include <gtest/gtest.h>
 
 using namespace recurse::systems;
+using recurse::simulation::cellForMaterial;
 using recurse::simulation::ChunkSlotState;
 using recurse::simulation::SimulationGrid;
 using recurse::simulation::VoxelCell;
@@ -72,7 +74,7 @@ class CollisionRadiusTest : public ::testing::Test {
         auto absent = addChunkRef(reg, cx, cy, cz);
         auto generating = transition<Absent, Generating>(absent, reg);
         grid.materializeChunk(cx, cy, cz);
-        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, VoxelCell{STONE});
+        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, cellForMaterial(STONE));
         grid.syncChunkBuffers(cx, cy, cz);
         transition<Generating, Active>(generating, reg);
     }

--- a/tests/unit/core/CrossChunkBoundaryTest.cc
+++ b/tests/unit/core/CrossChunkBoundaryTest.cc
@@ -1,4 +1,5 @@
 #include "fabric/world/ChunkedGrid.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkActivityTracker.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
@@ -16,6 +17,9 @@ using recurse::simulation::K_CHUNK_SIZE;
 using recurse::simulation::SimulationGrid;
 using recurse::simulation::VoxelCell;
 namespace MaterialIds = recurse::simulation::material_ids;
+using recurse::simulation::cellForMaterial;
+using recurse::simulation::cellMaterialId;
+using recurse::simulation::MaterialId;
 using recurse::systems::VoxelMeshingSystem;
 
 // =============================================================================
@@ -26,8 +30,8 @@ class SimulationGridCrossChunkTest : public ::testing::Test {
   protected:
     SimulationGrid grid;
 
-    void fillChunkWithSolid(int cx, int cy, int cz, uint16_t materialId = recurse::simulation::material_ids::STONE) {
-        VoxelCell cell{materialId, 0, 0};
+    void fillChunkWithSolid(int cx, int cy, int cz, MaterialId materialId = recurse::simulation::material_ids::STONE) {
+        VoxelCell cell = cellForMaterial(materialId);
         grid.fillChunk(cx, cy, cz, cell);
     }
 };
@@ -35,14 +39,14 @@ class SimulationGridCrossChunkTest : public ::testing::Test {
 TEST_F(SimulationGridCrossChunkTest, ReadCellReturnsAirForMissingChunk) {
     // Reading from a chunk that was never added should return air
     VoxelCell cell = grid.readCell(0, 0, 0);
-    EXPECT_EQ(cell.materialId, recurse::simulation::material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(cell), recurse::simulation::material_ids::AIR);
 }
 
 TEST_F(SimulationGridCrossChunkTest, ReadCellReturnsCorrectValueForExistingChunk) {
     fillChunkWithSolid(0, 0, 0, recurse::simulation::material_ids::STONE);
 
     VoxelCell cell = grid.readCell(0, 0, 0);
-    EXPECT_EQ(cell.materialId, recurse::simulation::material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(cell), recurse::simulation::material_ids::STONE);
 }
 
 TEST_F(SimulationGridCrossChunkTest, ReadCellCrossesChunkBoundary) {
@@ -51,10 +55,10 @@ TEST_F(SimulationGridCrossChunkTest, ReadCellCrossesChunkBoundary) {
 
     // Reading at local position (31,0,0) in chunk (0,0,0)
     // This is one voxel away from chunk (1,0,0)
-    EXPECT_EQ(grid.readCell(31, 0, 0).materialId, recurse::simulation::material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(31, 0, 0)), recurse::simulation::material_ids::STONE);
 
     // Reading at (32,0,0) is in chunk (1,0,0) which doesn't exist -> should return air
-    EXPECT_EQ(grid.readCell(32, 0, 0).materialId, recurse::simulation::material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(32, 0, 0)), recurse::simulation::material_ids::AIR);
 }
 
 TEST_F(SimulationGridCrossChunkTest, HasChunkReturnsCorrectStatus) {
@@ -73,8 +77,8 @@ TEST_F(SimulationGridCrossChunkTest, AdjacentChunkCoordinates) {
     fillChunkWithSolid(1, 0, 0);
 
     // Local 31 in chunk 0, local 0 in chunk 1
-    EXPECT_EQ(grid.readCell(31, 0, 0).materialId, recurse::simulation::material_ids::STONE);
-    EXPECT_EQ(grid.readCell(32, 0, 0).materialId, recurse::simulation::material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(31, 0, 0)), recurse::simulation::material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(32, 0, 0)), recurse::simulation::material_ids::STONE);
 }
 
 // =============================================================================
@@ -95,8 +99,8 @@ class CrossChunkMeshBoundaryTest : public ::testing::Test {
         meshingSystem.setRequireNeighborsForMeshing(false);
     }
 
-    void fillChunkRegion(int cx, int cy, int cz, uint16_t materialId = recurse::simulation::material_ids::STONE) {
-        VoxelCell cell{materialId, 0, 0};
+    void fillChunkRegion(int cx, int cy, int cz, MaterialId materialId = recurse::simulation::material_ids::STONE) {
+        VoxelCell cell = cellForMaterial(materialId);
         simGrid.fillChunk(cx, cy, cz, cell);
     }
 
@@ -106,7 +110,7 @@ class CrossChunkMeshBoundaryTest : public ::testing::Test {
         int baseY = cy * K_CHUNK_SIZE;
         int baseZ = cz * K_CHUNK_SIZE;
 
-        VoxelCell solid{recurse::simulation::material_ids::STONE, 0, 0};
+        VoxelCell solid = cellForMaterial(recurse::simulation::material_ids::STONE);
         for (int z = 0; z < K_CHUNK_SIZE; ++z) {
             for (int y = 0; y < K_CHUNK_SIZE; ++y) {
                 for (int x = 0; x < K_CHUNK_SIZE; ++x) {
@@ -193,7 +197,7 @@ TEST_F(CrossChunkMeshBoundaryTest, MeshBoundaryDiffersWithAndWithoutNeighbor) {
     systemA.setRequireNeighborsForMeshing(false); // Mesh without full neighbor set
     trackerA.setReferencePoint(0, 0, 0);
 
-    VoxelCell solid{recurse::simulation::material_ids::STONE, 0, 0};
+    VoxelCell solid = cellForMaterial(recurse::simulation::material_ids::STONE);
     for (int z = 0; z < K_CHUNK_SIZE; ++z) {
         for (int y = 0; y < K_CHUNK_SIZE; ++y) {
             for (int x = 0; x < K_CHUNK_SIZE; ++x) {
@@ -398,7 +402,7 @@ class ChunkLoadingSequenceTest : public ::testing::Test {
         int baseY = cy * K_CHUNK_SIZE;
         int baseZ = cz * K_CHUNK_SIZE;
 
-        VoxelCell solid{recurse::simulation::material_ids::STONE, 0, 0};
+        VoxelCell solid = cellForMaterial(recurse::simulation::material_ids::STONE);
         for (int z = 0; z < K_CHUNK_SIZE; ++z) {
             for (int y = 0; y < K_CHUNK_SIZE; ++y) {
                 for (int x = 0; x < K_CHUNK_SIZE; ++x) {
@@ -485,7 +489,7 @@ TEST_F(ChunkLoadingSequenceTest, AllSixNeighborsAffectMesh) {
         testTracker.setReferencePoint(0, 0, 0);
 
         // Fill center chunk
-        VoxelCell solid{recurse::simulation::material_ids::STONE, 0, 0};
+        VoxelCell solid = cellForMaterial(recurse::simulation::material_ids::STONE);
         for (int z = 0; z < K_CHUNK_SIZE; ++z) {
             for (int y = 0; y < K_CHUNK_SIZE; ++y) {
                 for (int x = 0; x < K_CHUNK_SIZE; ++x) {

--- a/tests/unit/core/FocalPointCollectionTest.cc
+++ b/tests/unit/core/FocalPointCollectionTest.cc
@@ -11,6 +11,7 @@
 #include "fabric/resource/AssetRegistry.hh"
 #include "fabric/resource/ResourceHub.hh"
 #include "recurse/components/StreamSource.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkRegistry.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
@@ -21,6 +22,7 @@
 
 using namespace recurse;
 using namespace recurse::systems;
+using recurse::simulation::cellForMaterial;
 using recurse::simulation::ChunkSlotState;
 using recurse::simulation::VoxelCell;
 using recurse::simulation::material_ids::STONE;
@@ -258,7 +260,7 @@ class FocalIntegrationTest : public ::testing::Test {
         auto absent = addChunkRef(reg, cx, cy, cz);
         auto generating = transition<Absent, Generating>(absent, reg);
         grid.materializeChunk(cx, cy, cz);
-        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, VoxelCell{STONE});
+        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, cellForMaterial(STONE));
         grid.syncChunkBuffers(cx, cy, cz);
         transition<Generating, Active>(generating, reg);
     }

--- a/tests/unit/core/IKSolverTest.cc
+++ b/tests/unit/core/IKSolverTest.cc
@@ -1,5 +1,6 @@
 #include "recurse/animation/IKSolver.hh"
 #include "recurse/animation/Animation.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 #include <cmath>
@@ -11,6 +12,7 @@
 
 using namespace fabric;
 using namespace recurse;
+using recurse::simulation::cellForMaterial;
 
 class TwoBoneIKTest : public ::testing::Test {
   protected:
@@ -328,7 +330,7 @@ class FootIKTest : public ::testing::Test {
         SimulationGrid grid;
         for (int x = -5; x <= 5; ++x) {
             for (int z = -5; z <= 5; ++z) {
-                grid.writeCellImmediate(x, groundVoxelY, z, VoxelCell{material_ids::STONE, 0, 0});
+                grid.writeCellImmediate(x, groundVoxelY, z, cellForMaterial(material_ids::STONE));
             }
         }
         return grid;
@@ -363,12 +365,12 @@ TEST_F(FootIKTest, SteppedTerrain) {
     SimulationGrid grid;
     for (int x = -5; x < 0; ++x) {
         for (int z = -5; z <= 5; ++z) {
-            grid.writeCellImmediate(x, -1, z, VoxelCell{material_ids::STONE, 0, 0});
+            grid.writeCellImmediate(x, -1, z, cellForMaterial(material_ids::STONE));
         }
     }
     for (int x = 0; x <= 5; ++x) {
         for (int z = -5; z <= 5; ++z) {
-            grid.writeCellImmediate(x, 0, z, VoxelCell{material_ids::STONE, 0, 0});
+            grid.writeCellImmediate(x, 0, z, cellForMaterial(material_ids::STONE));
         }
     }
 
@@ -398,7 +400,7 @@ TEST_F(FootIKTest, UnreachableGround) {
     SimulationGrid grid;
     for (int x = -5; x <= 5; ++x) {
         for (int z = -5; z <= 5; ++z) {
-            grid.writeCellImmediate(x, 2, z, VoxelCell{material_ids::STONE, 0, 0});
+            grid.writeCellImmediate(x, 2, z, cellForMaterial(material_ids::STONE));
         }
     }
 

--- a/tests/unit/core/LODGridTest.cc
+++ b/tests/unit/core/LODGridTest.cc
@@ -8,6 +8,7 @@
 #include "fabric/resource/ResourceHub.hh"
 #include "fixtures/BgfxNoopFixture.hh"
 #include "recurse/render/LODMeshManager.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/MaterialRegistry.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #define private public
@@ -70,7 +71,7 @@ void fillSectionFromGrid(LODSection& section, const SimulationGrid& grid, int cx
                 int wy = section.origin.y + ly;
                 int wz = section.origin.z + lz;
 
-                uint16_t matId = grid.readCell(wx, wy, wz).materialId;
+                uint16_t matId = cellMaterialId(grid.readCell(wx, wy, wz));
                 uint16_t palIdx = 0;
                 auto it = std::find(section.palette.begin(), section.palette.end(), matId);
                 if (it != section.palette.end()) {

--- a/tests/unit/core/MaterialSoundsTest.cc
+++ b/tests/unit/core/MaterialSoundsTest.cc
@@ -1,4 +1,5 @@
 #include "recurse/audio/MaterialSounds.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 
@@ -7,6 +8,7 @@
 
 using namespace fabric;
 using namespace recurse;
+using recurse::simulation::cellForMaterial;
 
 // Convenience alias
 using Ess = Vector4<float, Space::World>;
@@ -178,7 +180,7 @@ TEST(MaterialSoundsTest, DetectSurfaceBelowReturnsMaterial) {
     SimulationGrid grid;
     // Place a stone voxel one unit below the query point
     // Query at (5.5, 10.5, 5.5), solid at y=9
-    grid.writeCellImmediate(5, 9, 5, VoxelCell{material_ids::STONE, 0, 0});
+    grid.writeCellImmediate(5, 9, 5, cellForMaterial(material_ids::STONE));
 
     MaterialType result = ms.detectSurfaceBelow(grid, 5.5f, 10.5f, 5.5f);
     EXPECT_EQ(result, MaterialType::Stone);
@@ -200,7 +202,7 @@ TEST(MaterialSoundsTest, DetectSurfaceBelowBeyondMaxDistance) {
 
     SimulationGrid grid;
     // Place solid voxel 5 units below (beyond maxDistance of 2.0)
-    grid.writeCellImmediate(5, 5, 5, VoxelCell{material_ids::STONE, 0, 0});
+    grid.writeCellImmediate(5, 5, 5, cellForMaterial(material_ids::STONE));
 
     MaterialType result = ms.detectSurfaceBelow(grid, 5.5f, 10.5f, 5.5f);
     EXPECT_EQ(result, MaterialType::Default);

--- a/tests/unit/core/MeshingChunkContextTest.cc
+++ b/tests/unit/core/MeshingChunkContextTest.cc
@@ -1,3 +1,4 @@
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/systems/VoxelMeshingSystem.hh"
 
 #include "recurse/simulation/SimulationGrid.hh"
@@ -11,6 +12,9 @@ using recurse::simulation::SimulationGrid;
 using recurse::simulation::VoxelCell;
 using recurse::systems::MeshingChunkContext;
 namespace MaterialIds = recurse::simulation::material_ids;
+using recurse::simulation::cellForMaterial;
+using recurse::simulation::cellMaterialId;
+using recurse::simulation::MaterialId;
 
 class MeshingChunkContextTest : public ::testing::Test {
   protected:
@@ -54,8 +58,8 @@ class MeshingChunkContextTest : public ::testing::Test {
         simGrid.syncChunkBuffers(0, 0, -1);
     }
 
-    void fillAll(int cx, int cy, int cz, uint16_t materialId) {
-        VoxelCell cell{materialId};
+    void fillAll(int cx, int cy, int cz, MaterialId materialId) {
+        VoxelCell cell = cellForMaterial(materialId);
         int bx = cx * K_CHUNK_SIZE;
         int by = cy * K_CHUNK_SIZE;
         int bz = cz * K_CHUNK_SIZE;
@@ -65,11 +69,11 @@ class MeshingChunkContextTest : public ::testing::Test {
                     simGrid.writeCell(bx + lx, by + ly, bz + lz, cell);
     }
 
-    void writeSingleCell(int cx, int cy, int cz, int lx, int ly, int lz, uint16_t materialId) {
+    void writeSingleCell(int cx, int cy, int cz, int lx, int ly, int lz, MaterialId materialId) {
         int wx = cx * K_CHUNK_SIZE + lx;
         int wy = cy * K_CHUNK_SIZE + ly;
         int wz = cz * K_CHUNK_SIZE + lz;
-        simGrid.writeCell(wx, wy, wz, VoxelCell{materialId});
+        simGrid.writeCell(wx, wy, wz, cellForMaterial(materialId));
     }
 
     MeshingChunkContext buildCtx() {
@@ -95,37 +99,37 @@ class MeshingChunkContextTest : public ::testing::Test {
 TEST_F(MeshingChunkContextTest, ReadLocalInBounds) {
     auto ctx = buildCtx();
     auto cell = ctx.readLocal(0, 0, 0, &simGrid);
-    EXPECT_EQ(cell.materialId, MaterialIds::STONE);
+    EXPECT_EQ(cellMaterialId(cell), MaterialIds::STONE);
 
     auto mid = ctx.readLocal(K_CHUNK_SIZE / 2, K_CHUNK_SIZE / 2, K_CHUNK_SIZE / 2, &simGrid);
-    EXPECT_EQ(mid.materialId, MaterialIds::STONE);
+    EXPECT_EQ(cellMaterialId(mid), MaterialIds::STONE);
 
     auto edge = ctx.readLocal(K_CHUNK_SIZE - 1, K_CHUNK_SIZE - 1, K_CHUNK_SIZE - 1, &simGrid);
-    EXPECT_EQ(edge.materialId, MaterialIds::STONE);
+    EXPECT_EQ(cellMaterialId(edge), MaterialIds::STONE);
 }
 
 TEST_F(MeshingChunkContextTest, ReadLocalFaceNeighborPlusX) {
     auto ctx = buildCtx();
     auto cell = ctx.readLocal(K_CHUNK_SIZE, 0, 0, &simGrid);
-    EXPECT_EQ(cell.materialId, MaterialIds::DIRT);
+    EXPECT_EQ(cellMaterialId(cell), MaterialIds::DIRT);
 }
 
 TEST_F(MeshingChunkContextTest, ReadLocalFaceNeighborMinusX) {
     auto ctx = buildCtx();
     auto cell = ctx.readLocal(-1, 0, 0, &simGrid);
-    EXPECT_EQ(cell.materialId, MaterialIds::SAND);
+    EXPECT_EQ(cellMaterialId(cell), MaterialIds::SAND);
 }
 
 TEST_F(MeshingChunkContextTest, ReadLocalFaceNeighborPlusY) {
     auto ctx = buildCtx();
     auto cell = ctx.readLocal(0, K_CHUNK_SIZE, 0, &simGrid);
-    EXPECT_EQ(cell.materialId, MaterialIds::WATER);
+    EXPECT_EQ(cellMaterialId(cell), MaterialIds::WATER);
 }
 
 TEST_F(MeshingChunkContextTest, ReadLocalFaceNeighborMinusZ) {
     auto ctx = buildCtx();
     auto cell = ctx.readLocal(0, 0, -1, &simGrid);
-    EXPECT_EQ(cell.materialId, MaterialIds::WATER);
+    EXPECT_EQ(cellMaterialId(cell), MaterialIds::WATER);
 }
 
 TEST_F(MeshingChunkContextTest, ReadLocalNullNeighborReturnsFill) {
@@ -133,10 +137,10 @@ TEST_F(MeshingChunkContextTest, ReadLocalNullNeighborReturnsFill) {
 
     // Null out the +X neighbor (face index 0) and set its fill to GRAVEL
     ctx.neighbors[0] = nullptr;
-    ctx.neighborFill[0] = VoxelCell{MaterialIds::GRAVEL};
+    ctx.neighborFill[0] = cellForMaterial(MaterialIds::GRAVEL);
 
     auto cell = ctx.readLocal(K_CHUNK_SIZE, 5, 5, &simGrid);
-    EXPECT_EQ(cell.materialId, MaterialIds::GRAVEL);
+    EXPECT_EQ(cellMaterialId(cell), MaterialIds::GRAVEL);
 }
 
 TEST_F(MeshingChunkContextTest, ReadLocalEdgeCellFallback) {
@@ -145,7 +149,7 @@ TEST_F(MeshingChunkContextTest, ReadLocalEdgeCellFallback) {
     // The diagonal chunk (1,1,0) is not materialized, so readCell returns default VoxelCell{AIR}.
     auto ctx = buildCtx();
     auto cell = ctx.readLocal(K_CHUNK_SIZE, K_CHUNK_SIZE, 0, &simGrid);
-    EXPECT_EQ(cell.materialId, MaterialIds::AIR);
+    EXPECT_EQ(cellMaterialId(cell), MaterialIds::AIR);
 
     // Materialize the diagonal chunk with SAND and verify fallback resolves it
     simGrid.materializeChunk(1, 1, 0);
@@ -153,14 +157,14 @@ TEST_F(MeshingChunkContextTest, ReadLocalEdgeCellFallback) {
     simGrid.syncChunkBuffers(1, 1, 0);
 
     cell = ctx.readLocal(K_CHUNK_SIZE, K_CHUNK_SIZE, 0, &simGrid);
-    EXPECT_EQ(cell.materialId, MaterialIds::SAND);
+    EXPECT_EQ(cellMaterialId(cell), MaterialIds::SAND);
 }
 
 TEST_F(MeshingChunkContextTest, ReadLocalEdgeCellNullFallback) {
     auto ctx = buildCtx();
     // Corner cell: all 3 axes out of bounds, null fallback
     auto cell = ctx.readLocal(K_CHUNK_SIZE, K_CHUNK_SIZE, K_CHUNK_SIZE, static_cast<const SimulationGrid*>(nullptr));
-    EXPECT_EQ(cell.materialId, MaterialIds::AIR);
+    EXPECT_EQ(cellMaterialId(cell), MaterialIds::AIR);
 }
 
 TEST_F(MeshingChunkContextTest, BuildMeshingContextResolvesNeighbors) {

--- a/tests/unit/core/PhysicsWorldTest.cc
+++ b/tests/unit/core/PhysicsWorldTest.cc
@@ -1,6 +1,7 @@
 #include "recurse/physics/PhysicsWorld.hh"
 #include "fabric/platform/JobScheduler.hh"
 #include "fabric/world/ChunkedGrid.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 
@@ -811,7 +812,7 @@ TEST(PhysicsWorldTest, SimGridSingleVoxelProduces6Faces) {
 
     recurse::simulation::SimulationGrid grid;
     grid.materializeChunk(0, 0, 0);
-    grid.writeCell(4, 4, 4, {recurse::simulation::material_ids::STONE});
+    grid.writeCell(4, 4, 4, recurse::simulation::cellForMaterial(recurse::simulation::material_ids::STONE));
     grid.advanceEpoch();
 
     pw.rebuildChunkCollision(grid, 0, 0, 0);
@@ -826,8 +827,8 @@ TEST(PhysicsWorldTest, SimGridTwoAdjacentVoxels10Faces) {
 
     recurse::simulation::SimulationGrid grid;
     grid.materializeChunk(0, 0, 0);
-    grid.writeCell(4, 4, 4, {recurse::simulation::material_ids::STONE});
-    grid.writeCell(5, 4, 4, {recurse::simulation::material_ids::STONE});
+    grid.writeCell(4, 4, 4, recurse::simulation::cellForMaterial(recurse::simulation::material_ids::STONE));
+    grid.writeCell(5, 4, 4, recurse::simulation::cellForMaterial(recurse::simulation::material_ids::STONE));
     grid.advanceEpoch();
 
     pw.rebuildChunkCollision(grid, 0, 0, 0);
@@ -846,8 +847,9 @@ TEST(PhysicsWorldTest, BatchCollisionMatchesSequential) {
     for (int x = 0; x < 4; ++x)
         for (int y = 0; y < 4; ++y)
             for (int z = 0; z < 4; ++z) {
-                grid.writeCell(x, y, z, {recurse::simulation::material_ids::STONE});
-                grid.writeCell(32 + x, y, z, {recurse::simulation::material_ids::STONE});
+                grid.writeCell(x, y, z, recurse::simulation::cellForMaterial(recurse::simulation::material_ids::STONE));
+                grid.writeCell(32 + x, y, z,
+                               recurse::simulation::cellForMaterial(recurse::simulation::material_ids::STONE));
             }
     grid.advanceEpoch();
 
@@ -895,7 +897,7 @@ TEST(PhysicsWorldTest, BatchCollisionEmptyChunks) {
 TEST(PhysicsWorldTest, BatchCollisionReplacesExisting) {
     recurse::simulation::SimulationGrid grid;
     grid.materializeChunk(0, 0, 0);
-    grid.writeCell(4, 4, 4, {recurse::simulation::material_ids::STONE});
+    grid.writeCell(4, 4, 4, recurse::simulation::cellForMaterial(recurse::simulation::material_ids::STONE));
     grid.advanceEpoch();
 
     PhysicsWorld pw;
@@ -908,7 +910,7 @@ TEST(PhysicsWorldTest, BatchCollisionReplacesExisting) {
     EXPECT_EQ(pw.chunkCollisionShapeCount(0, 0, 0), 6u);
 
     // Add another voxel and rebuild
-    grid.writeCell(5, 4, 4, {recurse::simulation::material_ids::STONE});
+    grid.writeCell(5, 4, 4, recurse::simulation::cellForMaterial(recurse::simulation::material_ids::STONE));
     grid.advanceEpoch();
     pw.rebuildChunkCollisionBatch(grid, chunks, scheduler);
     EXPECT_EQ(pw.chunkCollisionShapeCount(0, 0, 0), 10u);

--- a/tests/unit/core/SubmitOpsTest.cc
+++ b/tests/unit/core/SubmitOpsTest.cc
@@ -10,6 +10,7 @@
 #include "fabric/resource/AssetRegistry.hh"
 #include "fabric/resource/ResourceHub.hh"
 #include "recurse/persistence/ChunkSaveService.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkRegistry.hh"
 #include "recurse/simulation/ChunkState.hh"
 #include "recurse/simulation/SimulationGrid.hh"
@@ -24,6 +25,7 @@
 namespace fs = std::filesystem;
 
 using namespace recurse::systems;
+using recurse::simulation::cellForMaterial;
 using recurse::simulation::VoxelCell;
 using recurse::simulation::material_ids::STONE;
 
@@ -91,7 +93,7 @@ class SubmitOpsTest : public ::testing::Test {
         auto absent = addChunkRef(reg, cx, cy, cz);
         auto generating = transition<Absent, Generating>(absent, reg);
         grid.materializeChunk(cx, cy, cz);
-        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, VoxelCell{STONE});
+        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, cellForMaterial(STONE));
         grid.syncChunkBuffers(cx, cy, cz);
         transition<Generating, Active>(generating, reg);
     }

--- a/tests/unit/core/TestWorldGeneratorTest.cc
+++ b/tests/unit/core/TestWorldGeneratorTest.cc
@@ -31,7 +31,7 @@ TEST(TestWorldGenerator, FlatWorldGenerator_BelowGround_Stone) {
     // Chunk (0,0,0) spans y=[0,31], entirely below groundLevel=32
     for (int y = 0; y < K_CHUNK_SIZE; ++y) {
         auto cell = grid.readCell(0, y, 0);
-        EXPECT_EQ(cell.materialId, material_ids::STONE) << "y=" << y << " should be stone";
+        EXPECT_EQ(cellMaterialId(cell), material_ids::STONE) << "y=" << y << " should be stone";
     }
 }
 
@@ -43,7 +43,7 @@ TEST(TestWorldGenerator, FlatWorldGenerator_AboveGround_Air) {
 
     for (int y = 64; y < 96; ++y) {
         auto cell = grid.readCell(0, y, 0);
-        EXPECT_EQ(cell.materialId, material_ids::AIR) << "y=" << y << " should be air";
+        EXPECT_EQ(cellMaterialId(cell), material_ids::AIR) << "y=" << y << " should be air";
     }
 }
 
@@ -58,12 +58,12 @@ TEST(TestWorldGenerator, LayeredWorldGenerator_StoneAndSand) {
     // Stone region: y=[0,27]
     for (int y = 0; y < 28; ++y) {
         auto cell = grid.readCell(0, y, 0);
-        EXPECT_EQ(cell.materialId, material_ids::STONE) << "y=" << y << " should be stone";
+        EXPECT_EQ(cellMaterialId(cell), material_ids::STONE) << "y=" << y << " should be stone";
     }
     // Sand region: y=[28,31]
     for (int y = 28; y < 32; ++y) {
         auto cell = grid.readCell(0, y, 0);
-        EXPECT_EQ(cell.materialId, material_ids::SAND) << "y=" << y << " should be sand";
+        EXPECT_EQ(cellMaterialId(cell), material_ids::SAND) << "y=" << y << " should be sand";
     }
 }
 
@@ -115,14 +115,14 @@ TEST(TestWorldGenerator, WorldGeneratorInterface_Swappable) {
     FlatWorldGenerator flat(32);
     flat.generate(grid, 0, 0, 0);
     grid.advanceEpoch();
-    EXPECT_EQ(grid.readCell(0, 28, 0).materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 28, 0)), material_ids::STONE);
 
     // Re-generate same chunk with LayeredWorldGenerator(28, 4):
     // y=28 should now be sand instead of stone
     LayeredWorldGenerator layered(28, 4);
     layered.generate(grid, 0, 0, 0);
     grid.advanceEpoch();
-    EXPECT_EQ(grid.readCell(0, 28, 0).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 28, 0)), material_ids::SAND);
 }
 
 TEST(TestWorldGenerator, GeneratorName_ReturnsCorrect) {
@@ -177,7 +177,7 @@ TEST(TestWorldGenerator, GenerateToBuffer_FlatBelowGround_AllStone) {
 
     for (int y = 0; y < K_CHUNK_SIZE; ++y) {
         int idx = 0 + y * K_CHUNK_SIZE + 0 * K_CHUNK_SIZE * K_CHUNK_SIZE;
-        EXPECT_EQ(buffer[idx].materialId, material_ids::STONE) << "y=" << y;
+        EXPECT_EQ(cellMaterialId(buffer[idx]), material_ids::STONE) << "y=" << y;
     }
 }
 
@@ -187,7 +187,7 @@ TEST(TestWorldGenerator, GenerateToBuffer_FlatAboveGround_AllAir) {
     gen.generateToBuffer(buffer.data(), 0, 2, 0);
 
     for (size_t i = 0; i < K_CHUNK_VOLUME; ++i) {
-        EXPECT_EQ(buffer[i].materialId, material_ids::AIR);
+        EXPECT_EQ(cellMaterialId(buffer[i]), material_ids::AIR);
     }
 }
 
@@ -206,7 +206,7 @@ TEST(TestWorldGenerator, GenerateToBuffer_FlatMatchesGenerate) {
     gen.generateToBuffer(buffer.data(), 0, 0, 0);
 
     for (size_t i = 0; i < K_CHUNK_VOLUME; ++i) {
-        EXPECT_EQ(buffer[i].materialId, fill.materialId) << "index=" << i;
+        EXPECT_EQ(cellMaterialId(buffer[i]), cellMaterialId(fill)) << "index=" << i;
     }
 }
 
@@ -227,7 +227,8 @@ TEST(TestWorldGenerator, GenerateToBuffer_LayeredMatchesGenerate) {
             for (int lx = 0; lx < K_CHUNK_SIZE; ++lx) {
                 int idx = lx + ly * K_CHUNK_SIZE + lz * K_CHUNK_SIZE * K_CHUNK_SIZE;
                 auto gridCell = grid.readCell(lx, ly, lz);
-                EXPECT_EQ(buffer[idx].materialId, gridCell.materialId) << "at (" << lx << "," << ly << "," << lz << ")";
+                EXPECT_EQ(cellMaterialId(buffer[idx]), cellMaterialId(gridCell))
+                    << "at (" << lx << "," << ly << "," << lz << ")";
             }
         }
     }
@@ -249,7 +250,7 @@ TEST(TestWorldGenerator, GenerateToBuffer_NaturalMatchesGenerate) {
     const auto* gridBuf = grid.readBuffer(0, 0, 0);
     ASSERT_NE(gridBuf, nullptr);
     for (size_t i = 0; i < K_CHUNK_VOLUME; ++i) {
-        EXPECT_EQ(buffer[i].materialId, (*gridBuf)[i].materialId) << "index=" << i;
+        EXPECT_EQ(cellMaterialId(buffer[i]), cellMaterialId((*gridBuf)[i])) << "index=" << i;
     }
 }
 
@@ -298,7 +299,7 @@ TEST(TestWorldGenerator, BatchGeneration_MatchesSequential) {
         ASSERT_NE(seqBuf, nullptr);
         ASSERT_NE(parBuf, nullptr);
         for (size_t i = 0; i < K_CHUNK_VOLUME; ++i) {
-            EXPECT_EQ((*parBuf)[i].materialId, (*seqBuf)[i].materialId)
+            EXPECT_EQ(cellMaterialId((*parBuf)[i]), cellMaterialId((*seqBuf)[i]))
                 << "chunk (" << cx << "," << cy << "," << cz << ") index=" << i;
         }
     }

--- a/tests/unit/core/VoxelInteractionTest.cc
+++ b/tests/unit/core/VoxelInteractionTest.cc
@@ -1,4 +1,5 @@
 #include "recurse/character/VoxelInteraction.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include <gtest/gtest.h>
 
 using namespace fabric;
@@ -8,6 +9,7 @@ using namespace recurse;
 class VoxelInteractionTest : public ::testing::Test {
   protected:
     SimulationGrid grid;
+    MaterialRegistry registry;
 
     void SetUp() override {
         // Ensure chunks exist for voxel operations at origin area and neighbors
@@ -21,119 +23,119 @@ class VoxelInteractionTest : public ::testing::Test {
 };
 
 TEST_F(VoxelInteractionTest, CreateMatterPlacesAdjacentPosZ) {
-    VoxelInteraction vi(grid);
+    VoxelInteraction vi(grid, registry);
     VoxelHit hit{5, 5, 5, 0, 0, 1, 1.0f}; // normal +Z
     auto result = vi.createMatter(hit);
     EXPECT_TRUE(result.success);
     EXPECT_EQ(result.x, 5);
     EXPECT_EQ(result.y, 5);
     EXPECT_EQ(result.z, 6);
-    EXPECT_EQ(result.newCell.materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(result.newCell), material_ids::SAND);
     EXPECT_EQ(result.source, ChangeSource::Place);
-    EXPECT_EQ(grid.readCell(5, 5, 6).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(5, 5, 6)), material_ids::AIR);
 }
 
 TEST_F(VoxelInteractionTest, CreateMatterPlacesAdjacentNegZ) {
-    VoxelInteraction vi(grid);
+    VoxelInteraction vi(grid, registry);
     VoxelHit hit{5, 5, 5, 0, 0, -1, 1.0f};
     auto result = vi.createMatter(hit);
     EXPECT_TRUE(result.success);
     EXPECT_EQ(result.z, 4);
-    EXPECT_EQ(result.newCell.materialId, material_ids::SAND);
-    EXPECT_EQ(grid.readCell(5, 5, 4).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(result.newCell), material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(5, 5, 4)), material_ids::AIR);
 }
 
 TEST_F(VoxelInteractionTest, CreateMatterPlacesAdjacentPosX) {
-    VoxelInteraction vi(grid);
+    VoxelInteraction vi(grid, registry);
     VoxelHit hit{5, 5, 5, 1, 0, 0, 1.0f};
     auto result = vi.createMatter(hit);
     EXPECT_EQ(result.x, 6);
-    EXPECT_EQ(result.newCell.materialId, material_ids::SAND);
-    EXPECT_EQ(grid.readCell(6, 5, 5).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(result.newCell), material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(6, 5, 5)), material_ids::AIR);
 }
 
 TEST_F(VoxelInteractionTest, CreateMatterPlacesAdjacentNegX) {
-    VoxelInteraction vi(grid);
+    VoxelInteraction vi(grid, registry);
     VoxelHit hit{5, 5, 5, -1, 0, 0, 1.0f};
     auto result = vi.createMatter(hit);
     EXPECT_EQ(result.x, 4);
 }
 
 TEST_F(VoxelInteractionTest, CreateMatterPlacesAdjacentPosY) {
-    VoxelInteraction vi(grid);
+    VoxelInteraction vi(grid, registry);
     VoxelHit hit{5, 5, 5, 0, 1, 0, 1.0f};
     auto result = vi.createMatter(hit);
     EXPECT_EQ(result.y, 6);
 }
 
 TEST_F(VoxelInteractionTest, CreateMatterPlacesAdjacentNegY) {
-    VoxelInteraction vi(grid);
+    VoxelInteraction vi(grid, registry);
     VoxelHit hit{5, 5, 5, 0, -1, 0, 1.0f};
     auto result = vi.createMatter(hit);
     EXPECT_EQ(result.y, 4);
 }
 
 TEST_F(VoxelInteractionTest, DestroyMatterSetsMaterialToAir) {
-    VoxelInteraction vi(grid);
-    grid.writeCellImmediate(5, 5, 5, VoxelCell{material_ids::STONE, 0, voxel_flags::NONE});
+    VoxelInteraction vi(grid, registry);
+    grid.writeCellImmediate(5, 5, 5, makeCell(static_cast<uint8_t>(material_ids::STONE), Phase::Solid, 200));
     VoxelHit hit{5, 5, 5, 0, 0, -1, 1.0f};
     auto result = vi.destroyMatter(hit);
     EXPECT_TRUE(result.success);
     EXPECT_EQ(result.x, 5);
-    EXPECT_EQ(result.newCell.materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(result.newCell), material_ids::AIR);
     EXPECT_EQ(result.source, ChangeSource::Destroy);
-    EXPECT_EQ(grid.readCell(5, 5, 5).materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(5, 5, 5)), material_ids::STONE);
 }
 
 TEST_F(VoxelInteractionTest, CreateMatterReturnsRequestedCellAndSource) {
-    VoxelInteraction vi(grid);
+    VoxelInteraction vi(grid, registry);
     VoxelHit hit{5, 5, 5, 0, 0, 1, 1.0f};
     auto result = vi.createMatter(hit);
     ASSERT_TRUE(result.success);
-    EXPECT_EQ(result.newCell.materialId, material_ids::SAND);
-    EXPECT_EQ(result.newCell.flags, voxel_flags::UPDATED);
+    EXPECT_EQ(cellMaterialId(result.newCell), material_ids::SAND);
+    EXPECT_NE(result.newCell.flags() & voxel_flags::UPDATED, 0);
     EXPECT_EQ(result.source, ChangeSource::Place);
 }
 
 TEST_F(VoxelInteractionTest, DestroyMatterReturnsRequestedCellAndSource) {
-    VoxelInteraction vi(grid);
-    grid.writeCellImmediate(5, 5, 5, VoxelCell{material_ids::STONE, 0, voxel_flags::NONE});
+    VoxelInteraction vi(grid, registry);
+    grid.writeCellImmediate(5, 5, 5, makeCell(static_cast<uint8_t>(material_ids::STONE), Phase::Solid, 200));
     VoxelHit hit{5, 5, 5, 0, 0, -1, 1.0f};
     auto result = vi.destroyMatter(hit);
     ASSERT_TRUE(result.success);
-    EXPECT_EQ(result.newCell.materialId, material_ids::AIR);
-    EXPECT_EQ(result.newCell.flags, voxel_flags::UPDATED);
+    EXPECT_EQ(cellMaterialId(result.newCell), material_ids::AIR);
+    EXPECT_NE(result.newCell.flags() & voxel_flags::UPDATED, 0);
     EXPECT_EQ(result.source, ChangeSource::Destroy);
 }
 
 TEST_F(VoxelInteractionTest, CreateMatterAtWithRaycast) {
-    VoxelInteraction vi(grid);
-    grid.writeCellImmediate(5, 5, 5, VoxelCell{material_ids::STONE, 0, voxel_flags::NONE});
+    VoxelInteraction vi(grid, registry);
+    grid.writeCellImmediate(5, 5, 5, makeCell(static_cast<uint8_t>(material_ids::STONE), Phase::Solid, 200));
     auto result = vi.createMatterAt(5.5f, 5.5f, 0.5f, 0.0f, 0.0f, 1.0f);
     EXPECT_TRUE(result.success);
     // Ray hits +Z face of voxel at (5,5,5), normal is (0,0,-1), so placement at (5,5,4)
     EXPECT_EQ(result.z, 4);
-    EXPECT_EQ(result.newCell.materialId, material_ids::SAND);
-    EXPECT_EQ(grid.readCell(5, 5, 4).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(result.newCell), material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(5, 5, 4)), material_ids::AIR);
 }
 
 TEST_F(VoxelInteractionTest, DestroyMatterAtWithRaycast) {
-    VoxelInteraction vi(grid);
-    grid.writeCellImmediate(5, 5, 5, VoxelCell{material_ids::STONE, 0, voxel_flags::NONE});
+    VoxelInteraction vi(grid, registry);
+    grid.writeCellImmediate(5, 5, 5, makeCell(static_cast<uint8_t>(material_ids::STONE), Phase::Solid, 200));
     auto result = vi.destroyMatterAt(5.5f, 5.5f, 0.5f, 0.0f, 0.0f, 1.0f);
     EXPECT_TRUE(result.success);
-    EXPECT_EQ(result.newCell.materialId, material_ids::AIR);
-    EXPECT_EQ(grid.readCell(5, 5, 5).materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(result.newCell), material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(5, 5, 5)), material_ids::STONE);
 }
 
 TEST_F(VoxelInteractionTest, CreateMatterAtNoHitReturnsFail) {
-    VoxelInteraction vi(grid);
+    VoxelInteraction vi(grid, registry);
     auto result = vi.createMatterAt(0.5f, 0.5f, 0.5f, 1.0f, 0.0f, 0.0f);
     EXPECT_FALSE(result.success);
 }
 
 TEST_F(VoxelInteractionTest, DestroyMatterAtNoHitReturnsFail) {
-    VoxelInteraction vi(grid);
+    VoxelInteraction vi(grid, registry);
     auto result = vi.destroyMatterAt(0.5f, 0.5f, 0.5f, 1.0f, 0.0f, 0.0f);
     EXPECT_FALSE(result.success);
 }
@@ -149,19 +151,19 @@ TEST_F(VoxelInteractionTest, WouldOverlapNoIntersection) {
 }
 
 TEST_F(VoxelInteractionTest, NegativeCoordinatesWork) {
-    VoxelInteraction vi(grid);
+    VoxelInteraction vi(grid, registry);
     VoxelHit hit{-5, -3, -7, 0, 0, -1, 1.0f};
     auto result = vi.createMatter(hit);
     EXPECT_TRUE(result.success);
     EXPECT_EQ(result.x, -5);
     EXPECT_EQ(result.y, -3);
     EXPECT_EQ(result.z, -8);
-    EXPECT_EQ(result.newCell.materialId, material_ids::SAND);
-    EXPECT_EQ(grid.readCell(-5, -3, -8).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(result.newCell), material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(-5, -3, -8)), material_ids::AIR);
 }
 
 TEST_F(VoxelInteractionTest, ChunkCoordsCalculatedCorrectly) {
-    VoxelInteraction vi(grid);
+    VoxelInteraction vi(grid, registry);
     VoxelHit hit{31, 0, 0, 1, 0, 0, 1.0f}; // normal +X, target = (32, 0, 0)
     auto result = vi.createMatter(hit);
     EXPECT_EQ(result.x, 32);

--- a/tests/unit/core/VoxelMeshingSystemTest.cc
+++ b/tests/unit/core/VoxelMeshingSystemTest.cc
@@ -1,5 +1,6 @@
 #define private public
 #include "recurse/systems/VoxelMeshingSystem.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #undef private
 
 #include "fabric/world/ChunkedGrid.hh"
@@ -19,6 +20,8 @@ using recurse::simulation::K_CHUNK_SIZE;
 using recurse::simulation::SimulationGrid;
 using recurse::simulation::VoxelCell;
 namespace MaterialIds = recurse::simulation::material_ids;
+using recurse::simulation::cellForMaterial;
+using recurse::simulation::cellMaterialId;
 using recurse::systems::VoxelMeshingSystem;
 
 class VoxelMeshingSystemTest : public ::testing::Test {
@@ -38,8 +41,7 @@ class VoxelMeshingSystemTest : public ::testing::Test {
     }
 
     void fillChunkSolid(const ChunkCoord& coord) {
-        VoxelCell solid;
-        solid.materialId = MaterialIds::STONE;
+        VoxelCell solid = cellForMaterial(MaterialIds::STONE);
         simGrid.fillChunk(coord.x, coord.y, coord.z, solid);
     }
 };
@@ -131,9 +133,7 @@ TEST_F(VoxelMeshingSystemTest, GreedySelectionLeavesSingleExposedFaceAsOneQuad) 
 
 TEST_F(VoxelMeshingSystemTest, GreedySelectionPreservesPaletteContractAndShaderAOPacking) {
     ChunkCoord coord{0, 0, 0};
-    VoxelCell sand;
-    sand.materialId = MaterialIds::SAND;
-    sand.essenceIdx = 0;
+    VoxelCell sand = cellForMaterial(MaterialIds::SAND);
     simGrid.fillChunk(coord.x, coord.y, coord.z, sand);
 
     auto* palette = simGrid.chunkPalette(coord.x, coord.y, coord.z);
@@ -301,8 +301,7 @@ TEST_F(VoxelMeshingSystemTest, MeshUpdateReplacesOld) {
 
 TEST_F(VoxelMeshingSystemTest, KnownVoxelFieldMesh) {
     ChunkCoord coord{0, 0, 0};
-    VoxelCell solid;
-    solid.materialId = MaterialIds::STONE;
+    VoxelCell solid = cellForMaterial(MaterialIds::STONE);
 
     // Fill bottom half (y < 16) with stone, top half remains air
     for (int z = 0; z < K_CHUNK_SIZE; ++z)
@@ -345,9 +344,7 @@ TEST_F(VoxelMeshingSystemTest, DebugCountersTrackMeshLifecycleWithoutRescans) {
 
 TEST_F(VoxelMeshingSystemTest, FullResPaletteUsesMaterialAppearanceContractNotChunkEssence) {
     ChunkCoord coord{0, 0, 0};
-    VoxelCell sand;
-    sand.materialId = MaterialIds::SAND;
-    sand.essenceIdx = 0;
+    VoxelCell sand = cellForMaterial(MaterialIds::SAND);
     simGrid.fillChunk(coord.x, coord.y, coord.z, sand);
 
     auto* palette = simGrid.chunkPalette(coord.x, coord.y, coord.z);

--- a/tests/unit/core/VoxelRaycastTest.cc
+++ b/tests/unit/core/VoxelRaycastTest.cc
@@ -1,4 +1,5 @@
 #include "recurse/world/VoxelRaycast.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 #include <gtest/gtest.h>
@@ -95,7 +96,7 @@ TEST_F(VoxelRaycastSimGridTest, RayHitsSolidVoxelInSimGrid) {
     grid.fillChunk(0, 0, 0, VoxelCell{});
 
     VoxelCell stoneCell{};
-    stoneCell.materialId = material_ids::STONE;
+    stoneCell = cellForMaterial(material_ids::STONE);
     grid.writeCell(5, 5, 5, stoneCell);
     grid.advanceEpoch();
 
@@ -121,7 +122,7 @@ TEST_F(VoxelRaycastSimGridTest, CastRayAllSimGridReturnsMultipleHits) {
     grid.fillChunk(0, 0, 0, VoxelCell{});
 
     VoxelCell stoneCell{};
-    stoneCell.materialId = material_ids::STONE;
+    stoneCell = cellForMaterial(material_ids::STONE);
     grid.writeCell(5, 5, 3, stoneCell);
     grid.writeCell(5, 5, 6, stoneCell);
     grid.writeCell(5, 5, 9, stoneCell);

--- a/tests/unit/core/WorldContextBenchmark.cc
+++ b/tests/unit/core/WorldContextBenchmark.cc
@@ -11,6 +11,7 @@
 #include "fabric/platform/JobScheduler.hh"
 #include "fabric/resource/AssetRegistry.hh"
 #include "fabric/resource/ResourceHub.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkRegistry.hh"
 #include "recurse/simulation/ChunkState.hh"
 #include "recurse/simulation/SimulationGrid.hh"
@@ -26,6 +27,7 @@
 namespace fs = std::filesystem;
 
 using namespace recurse::systems;
+using recurse::simulation::cellForMaterial;
 using recurse::simulation::ChunkSlotState;
 using recurse::simulation::VoxelCell;
 using recurse::simulation::material_ids::STONE;
@@ -108,7 +110,7 @@ class WorldContextBenchmark : public ::testing::Test {
         auto absent = addChunkRef(reg, cx, cy, cz);
         auto generating = transition<Absent, Generating>(absent, reg);
         grid.materializeChunk(cx, cy, cz);
-        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, VoxelCell{STONE});
+        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, cellForMaterial(STONE));
         grid.syncChunkBuffers(cx, cy, cz);
         transition<Generating, Active>(generating, reg);
     }

--- a/tests/unit/core/WorldContextTest.cc
+++ b/tests/unit/core/WorldContextTest.cc
@@ -9,6 +9,7 @@
 #include "fabric/platform/JobScheduler.hh"
 #include "fabric/resource/AssetRegistry.hh"
 #include "fabric/resource/ResourceHub.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkRegistry.hh"
 #include "recurse/simulation/ChunkState.hh"
 #include "recurse/simulation/SimulationGrid.hh"
@@ -24,6 +25,7 @@
 namespace fs = std::filesystem;
 
 using namespace recurse::systems;
+using recurse::simulation::cellForMaterial;
 using recurse::simulation::ChunkSlotState;
 using recurse::simulation::VoxelCell;
 using recurse::simulation::material_ids::STONE;
@@ -91,7 +93,7 @@ class WorldContextTest : public ::testing::Test {
         auto absent = addChunkRef(reg, cx, cy, cz);
         auto generating = transition<Absent, Generating>(absent, reg);
         grid.materializeChunk(cx, cy, cz);
-        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, VoxelCell{STONE});
+        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, cellForMaterial(STONE));
         grid.syncChunkBuffers(cx, cy, cz);
         transition<Generating, Active>(generating, reg);
     }

--- a/tests/unit/persistence/FchkCodecTest.cc
+++ b/tests/unit/persistence/FchkCodecTest.cc
@@ -1,5 +1,7 @@
 #include "recurse/persistence/FchkCodec.hh"
 #include "fabric/utils/ErrorHandling.hh"
+#include "recurse/simulation/CellAccessors.hh"
+#include "recurse/simulation/MatterState.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 #include <algorithm>
 #include <cstring>
@@ -16,13 +18,52 @@ class FchkCodecTest : public ::testing::Test {
 
     static std::vector<uint8_t> makeEmptyChunk() { return std::vector<uint8_t>(K_CELLS_BYTE_COUNT, 0); }
 
-    static std::vector<uint8_t> makeUniformChunk(uint16_t materialId, uint8_t essenceIdx, uint8_t flags) {
+    /// Build a uniform chunk in new v4 layout: [essenceIdx, displacementRank, phaseAndFlags, spare].
+    /// essenceIdx == materialId during migration. Phase and displacementRank are derived from materialId.
+    /// flags occupy bits 3-7 of phaseAndFlags (shifted left by 3).
+    static std::vector<uint8_t> makeUniformChunk(uint16_t materialId, uint8_t /*essenceIdx*/, uint8_t flags) {
+        using namespace simulation;
+        uint8_t essence = static_cast<uint8_t>(materialId);
+        uint8_t phase = 0;
+        uint8_t density = 0;
+        switch (materialId) {
+            case material_ids::AIR:
+                phase = 0;
+                density = 0;
+                break;
+            case material_ids::STONE:
+                phase = 1;
+                density = 200;
+                break;
+            case material_ids::DIRT:
+                phase = 1;
+                density = 150;
+                break;
+            case material_ids::SAND:
+                phase = 2;
+                density = 130;
+                break;
+            case material_ids::WATER:
+                phase = 3;
+                density = 100;
+                break;
+            case material_ids::GRAVEL:
+                phase = 2;
+                density = 170;
+                break;
+            default:
+                phase = 1;
+                density = 128;
+                break;
+        }
+        uint8_t phaseAndFlags = static_cast<uint8_t>((phase & 0x07) | ((flags & 0x1F) << 3));
         std::vector<uint8_t> cells(K_CELLS_BYTE_COUNT);
         for (size_t i = 0; i < K_CELL_COUNT; ++i) {
             size_t base = i * 4;
-            std::memcpy(&cells[base], &materialId, 2);
-            cells[base + 2] = essenceIdx;
-            cells[base + 3] = flags;
+            cells[base + 0] = essence;       // essenceIdx
+            cells[base + 1] = density;       // displacementRank
+            cells[base + 2] = phaseAndFlags; // phase | (flags << 3)
+            cells[base + 3] = 0;             // spare
         }
         return cells;
     }
@@ -38,10 +79,11 @@ class FchkCodecTest : public ::testing::Test {
         return {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 0.0f, 0.05f};
     }
 
+    /// Expected cells after v4 decode: runtime flags (bits 3-4 of phaseAndFlags, byte 2) cleared.
     static std::vector<uint8_t> expectedCells(const std::vector<uint8_t>& cells) {
         auto expected = cells;
-        constexpr uint8_t kMask = static_cast<uint8_t>(~(0x01 | 0x02));
-        for (size_t i = 3; i < expected.size(); i += 4) {
+        constexpr uint8_t kMask = static_cast<uint8_t>(~(0x08 | 0x10));
+        for (size_t i = 2; i < expected.size(); i += 4) {
             expected[i] &= kMask;
         }
         return expected;
@@ -133,8 +175,9 @@ TEST_F(FchkCodecTest, RuntimeFlagsClearedOnDecode) {
     for (uint8_t comp : {0, 1, 2}) {
         auto blob = FchkCodec::encode(cells.data(), cells.size(), comp);
         auto decoded = FchkCodec::decode(blob);
-        for (size_t i = 3; i < decoded.cells.size(); i += 4) {
-            EXPECT_EQ(decoded.cells[i] & 0x03, 0)
+        // v4 layout: runtime flags are bits 3-4 of phaseAndFlags (byte 2 of each cell)
+        for (size_t i = 2; i < decoded.cells.size(); i += 4) {
+            EXPECT_EQ(decoded.cells[i] & 0x18, 0)
                 << "Runtime flags not cleared at offset " << i << " for compression=" << static_cast<int>(comp);
         }
     }
@@ -172,10 +215,11 @@ TEST_F(FchkCodecTest, DeltaPartialDiffs) {
 
     for (size_t i = 0; i < modCount; ++i) {
         size_t base = indices[i] * 4;
-        uint16_t newMat = simulation::material_ids::SAND;
-        std::memcpy(&current[base], &newMat, 2);
-        current[base + 2] = 1;
-        current[base + 3] = 0;
+        // v4 layout: [essenceIdx, displacementRank, phaseAndFlags, spare]
+        current[base + 0] = static_cast<uint8_t>(simulation::material_ids::SAND); // essenceIdx
+        current[base + 1] = 130;                                                  // displacementRank for SAND
+        current[base + 2] = 2;                                                    // Phase::Powder, no flags
+        current[base + 3] = 0;                                                    // spare
     }
 
     auto blob = FchkCodec::encodeDelta(current.data(), reference.data(), current.size(), 42, 0);
@@ -203,8 +247,10 @@ TEST_F(FchkCodecTest, DeltaAllDiffs) {
 TEST_F(FchkCodecTest, DeltaZstdCompression) {
     auto reference = makeUniformChunk(simulation::material_ids::STONE, 0, 0);
     auto current = reference;
-    uint16_t newMat = simulation::material_ids::SAND;
-    std::memcpy(&current[0], &newMat, 2);
+    // v4 layout: change cell 0 to SAND
+    current[0] = static_cast<uint8_t>(simulation::material_ids::SAND);
+    current[1] = 130; // displacementRank for SAND
+    current[2] = 2;   // Phase::Powder
 
     auto blob = FchkCodec::encodeDelta(current.data(), reference.data(), current.size(), 1, 1);
     auto delta = FchkCodec::decodeDelta(blob);
@@ -218,8 +264,10 @@ TEST_F(FchkCodecTest, DeltaZstdCompression) {
 TEST_F(FchkCodecTest, DeltaLz4Compression) {
     auto reference = makeUniformChunk(simulation::material_ids::STONE, 0, 0);
     auto current = reference;
-    uint16_t newMat = simulation::material_ids::SAND;
-    std::memcpy(&current[0], &newMat, 2);
+    // v4 layout: change cell 0 to SAND
+    current[0] = static_cast<uint8_t>(simulation::material_ids::SAND);
+    current[1] = 130; // displacementRank for SAND
+    current[2] = 2;   // Phase::Powder
 
     auto blob = FchkCodec::encodeDelta(current.data(), reference.data(), current.size(), 1, 2);
     auto delta = FchkCodec::decodeDelta(blob);
@@ -233,9 +281,10 @@ TEST_F(FchkCodecTest, DeltaLz4Compression) {
 TEST_F(FchkCodecTest, DeltaWithPalette) {
     auto reference = makeUniformChunk(simulation::material_ids::STONE, 0, 0);
     auto current = reference;
-    uint16_t newMat = simulation::material_ids::SAND;
-    std::memcpy(&current[0], &newMat, 2);
-    current[2] = 1;
+    // v4 layout: change cell 0 to SAND
+    current[0] = static_cast<uint8_t>(simulation::material_ids::SAND);
+    current[1] = 130; // displacementRank for SAND
+    current[2] = 2;   // Phase::Powder
 
     auto pal = makeSamplePalette();
     auto blob = FchkCodec::encodeDelta(current.data(), reference.data(), current.size(), 55, 1, 1, pal.data(), 3);
@@ -283,12 +332,184 @@ TEST_F(FchkCodecTest, DeltaSmallerThanFull) {
 
     for (size_t i = 0; i < modCount; ++i) {
         size_t base = indices[i] * 4;
-        uint16_t newMat = simulation::material_ids::SAND;
-        std::memcpy(&current[base], &newMat, 2);
+        // v4 layout: change to SAND
+        current[base + 0] = static_cast<uint8_t>(simulation::material_ids::SAND);
+        current[base + 1] = 130;
+        current[base + 2] = 2;
+        current[base + 3] = 0;
     }
 
     auto deltaBlob = FchkCodec::encodeDelta(current.data(), reference.data(), current.size(), 0, 1);
     auto fullBlob = FchkCodec::encode(current.data(), current.size(), 1);
     EXPECT_LT(deltaBlob.size(), fullBlob.size())
         << "Delta blob (" << deltaBlob.size() << ") should be smaller than full blob (" << fullBlob.size() << ")";
+}
+
+// --- v4 MatterState layout tests ---
+
+class FchkCodecV4Test : public ::testing::Test {
+  protected:
+    static constexpr size_t K_CELL_COUNT = 32 * 32 * 32;
+    static constexpr size_t K_CELLS_BYTE_COUNT = K_CELL_COUNT * 4;
+
+    using Phase = simulation::Phase;
+    using MatterState = simulation::MatterState;
+
+    /// Build a chunk of uniform MatterState cells in raw byte form.
+    static std::vector<uint8_t> makeMatterChunk(uint8_t essenceIdx, Phase phase, uint8_t displacementRank = 0,
+                                                uint8_t flags = 0) {
+        MatterState cell;
+        cell.essenceIdx = essenceIdx;
+        cell.displacementRank = displacementRank;
+        cell.setPhase(phase);
+        cell.setFlags(flags);
+        std::vector<uint8_t> cells(K_CELLS_BYTE_COUNT);
+        for (size_t i = 0; i < K_CELL_COUNT; ++i) {
+            std::memcpy(&cells[i * 4], &cell, 4);
+        }
+        return cells;
+    }
+
+    /// Patch a blob's header version from 2 to a target version.
+    /// FchkHeader layout: magic[4] + version[2] (LE) + dims[3] + compression[1].
+    static void patchVersion(ChunkBlob& blob, uint16_t version) {
+        std::memcpy(blob.data_ptr() + 4, &version, sizeof(uint16_t));
+    }
+
+    /// Encode cells as uncompressed v2 blob, then patch header to v4.
+    static ChunkBlob encodeAsV4(const void* cells, size_t cellsByteCount, uint8_t compression = 0, int level = 1,
+                                const float* paletteData = nullptr, uint16_t paletteEntryCount = 0) {
+        auto blob = FchkCodec::encode(cells, cellsByteCount, compression, level, paletteData, paletteEntryCount);
+        patchVersion(blob, 4);
+        return blob;
+    }
+
+    /// Expected cells after v4 decode: runtime flags (bits 3-4 of phaseAndFlags, byte 2) cleared.
+    static std::vector<uint8_t> expectedV4Cells(const std::vector<uint8_t>& cells) {
+        auto expected = cells;
+        constexpr uint8_t kMask = static_cast<uint8_t>(~(0x08 | 0x10));
+        for (size_t i = 2; i < expected.size(); i += 4) {
+            expected[i] &= kMask;
+        }
+        return expected;
+    }
+
+    static std::vector<float> makeSamplePalette() {
+        return {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 0.0f, 0.05f};
+    }
+};
+
+TEST_F(FchkCodecV4Test, RoundTrip) {
+    auto cells = makeMatterChunk(1, Phase::Solid, 128);
+    auto blob = encodeAsV4(cells.data(), cells.size());
+
+    auto decoded = FchkCodec::decode(blob);
+    auto expected = expectedV4Cells(cells);
+    ASSERT_EQ(decoded.cells.size(), expected.size());
+    EXPECT_TRUE(std::equal(decoded.cells.begin(), decoded.cells.end(), expected.begin()))
+        << "v4 round-trip cell data mismatch";
+}
+
+TEST_F(FchkCodecV4Test, RuntimeFlagsCleared) {
+    // Set UPDATED (flags bit 0 -> phaseAndFlags bit 3) and FREE_FALL (flags bit 1 -> phaseAndFlags bit 4)
+    constexpr uint8_t kUpdated = 1;  // flags bit 0
+    constexpr uint8_t kFreeFall = 2; // flags bit 1
+    auto cells = makeMatterChunk(2, Phase::Powder, 64, kUpdated | kFreeFall);
+
+    // Verify the raw phaseAndFlags byte has bits 3-4 set
+    MatterState probe;
+    std::memcpy(&probe, &cells[0], 4);
+    ASSERT_NE(probe.phaseAndFlags & 0x18, 0) << "Test setup: runtime flags should be set in phaseAndFlags";
+
+    auto blob = encodeAsV4(cells.data(), cells.size());
+    auto decoded = FchkCodec::decode(blob);
+
+    for (size_t i = 0; i < K_CELL_COUNT; ++i) {
+        size_t base = i * 4;
+        MatterState decodedCell;
+        std::memcpy(&decodedCell, &decoded.cells[base], 4);
+
+        // Phase (low 3 bits) must be preserved
+        EXPECT_EQ(decodedCell.phase(), Phase::Powder) << "Phase lost at cell " << i;
+
+        // Runtime flags (bits 3-4 of phaseAndFlags) must be cleared
+        EXPECT_EQ(decodedCell.phaseAndFlags & 0x18, 0) << "Runtime flags not cleared at cell " << i;
+
+        // essenceIdx and displacementRank untouched
+        EXPECT_EQ(decodedCell.essenceIdx, 2) << "essenceIdx corrupted at cell " << i;
+        EXPECT_EQ(decodedCell.displacementRank, 64) << "displacementRank corrupted at cell " << i;
+    }
+}
+
+TEST_F(FchkCodecV4Test, PaletteRoundTrip) {
+    auto cells = makeMatterChunk(1, Phase::Solid, 128);
+    auto pal = makeSamplePalette();
+
+    auto blob = encodeAsV4(cells.data(), cells.size(), 0, 1, pal.data(), 3);
+    auto decoded = FchkCodec::decode(blob);
+
+    EXPECT_EQ(decoded.paletteEntryCount, 3u);
+    ASSERT_EQ(decoded.paletteData.size(), 12u);
+    for (size_t i = 0; i < decoded.paletteData.size(); ++i) {
+        EXPECT_FLOAT_EQ(decoded.paletteData[i], pal[i]) << "palette float " << i;
+    }
+}
+
+TEST_F(FchkCodecV4Test, WithZstd) {
+    auto cells = makeMatterChunk(3, Phase::Liquid, 32);
+    auto blob = encodeAsV4(cells.data(), cells.size(), 1);
+
+    auto decoded = FchkCodec::decode(blob);
+    auto expected = expectedV4Cells(cells);
+    ASSERT_EQ(decoded.cells.size(), expected.size());
+    EXPECT_TRUE(std::equal(decoded.cells.begin(), decoded.cells.end(), expected.begin()))
+        << "v4 zstd round-trip cell data mismatch";
+}
+
+TEST_F(FchkCodecV4Test, WithLz4) {
+    auto cells = makeMatterChunk(4, Phase::Gas, 16);
+    auto blob = encodeAsV4(cells.data(), cells.size(), 2);
+
+    auto decoded = FchkCodec::decode(blob);
+    auto expected = expectedV4Cells(cells);
+    ASSERT_EQ(decoded.cells.size(), expected.size());
+    EXPECT_TRUE(std::equal(decoded.cells.begin(), decoded.cells.end(), expected.begin()))
+        << "v4 LZ4 round-trip cell data mismatch";
+}
+
+TEST_F(FchkCodecV4Test, PhasePreservedAcrossAllValues) {
+    // Test every Phase enum value round-trips through v4 decode
+    for (uint8_t p = 0; p <= 4; ++p) {
+        auto phase = static_cast<Phase>(p);
+        auto cells = makeMatterChunk(p + 1, phase, p * 50);
+
+        auto blob = encodeAsV4(cells.data(), cells.size());
+        auto decoded = FchkCodec::decode(blob);
+
+        MatterState decodedCell;
+        std::memcpy(&decodedCell, &decoded.cells[0], 4);
+        EXPECT_EQ(decodedCell.phase(), phase) << "Phase not preserved for Phase=" << static_cast<int>(p);
+        EXPECT_EQ(decodedCell.essenceIdx, p + 1) << "essenceIdx corrupted for Phase=" << static_cast<int>(p);
+        EXPECT_EQ(decodedCell.displacementRank, p * 50)
+            << "displacementRank corrupted for Phase=" << static_cast<int>(p);
+    }
+}
+
+TEST_F(FchkCodecV4Test, DecodeAnyHandlesV4) {
+    auto cells = makeMatterChunk(1, Phase::Solid, 128);
+    auto blob = encodeAsV4(cells.data(), cells.size());
+
+    // decodeAny delegates to decode for non-v3 blobs
+    auto decoded = FchkCodec::decodeAny(blob);
+    auto expected = expectedV4Cells(cells);
+    ASSERT_EQ(decoded.cells.size(), expected.size());
+    EXPECT_TRUE(std::equal(decoded.cells.begin(), decoded.cells.end(), expected.begin()))
+        << "v4 decodeAny cell data mismatch";
+}
+
+TEST_F(FchkCodecV4Test, UnsupportedVersionRejected) {
+    auto cells = makeMatterChunk(1, Phase::Solid);
+    auto blob = encodeAsV4(cells.data(), cells.size());
+    patchVersion(blob, 5);
+    EXPECT_THROW(FchkCodec::decode(blob), fabric::FabricException);
 }

--- a/tests/unit/persistence/PollPendingLoadsTest.cc
+++ b/tests/unit/persistence/PollPendingLoadsTest.cc
@@ -1,4 +1,5 @@
 #include "recurse/persistence/WorldSession.hh"
+#include "recurse/simulation/CellAccessors.hh"
 
 #include "fabric/core/AppContext.hh"
 #include "fabric/core/SystemRegistry.hh"
@@ -23,6 +24,7 @@
 namespace fs = std::filesystem;
 
 using namespace recurse::systems;
+using recurse::simulation::cellForMaterial;
 using recurse::simulation::VoxelCell;
 using recurse::simulation::material_ids::STONE;
 
@@ -86,7 +88,7 @@ class PollPendingLoadsTest : public ::testing::Test {
         auto absent = addChunkRef(reg, cx, cy, cz);
         auto generating = transition<Absent, Generating>(absent, reg);
         grid.materializeChunk(cx, cy, cz);
-        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, VoxelCell{STONE});
+        grid.writeCell(cx * 32 + 4, cy * 32 + 4, cz * 32 + 4, cellForMaterial(STONE));
         grid.syncChunkBuffers(cx, cy, cz);
         transition<Generating, Active>(generating, reg);
     }
@@ -155,7 +157,9 @@ TEST_F(PollPendingLoadsTest, PersistPendingChunkReloadsBeforeDbCommit) {
     auto completions = session_->pollPendingLoads();
     ASSERT_EQ(completions.size(), 1u);
     EXPECT_TRUE(completions[0].success);
-    EXPECT_EQ(voxelSim_->simulationGrid().readCell(K_CX * 32 + 4, K_CY * 32 + 4, K_CZ * 32 + 4).materialId, STONE);
+    EXPECT_EQ(recurse::simulation::cellMaterialId(
+                  voxelSim_->simulationGrid().readCell(K_CX * 32 + 4, K_CY * 32 + 4, K_CZ * 32 + 4)),
+              STONE);
 
     EXPECT_TRUE(saveService->hasPersistPending(K_CX, K_CY, K_CZ));
 

--- a/tests/unit/persistence/ReplayExecutorTest.cc
+++ b/tests/unit/persistence/ReplayExecutorTest.cc
@@ -2,6 +2,7 @@
 #include "recurse/character/VoxelInteraction.hh"
 #include "recurse/persistence/FchkCodec.hh"
 #include "recurse/persistence/WorldTransactionStore.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkActivityTracker.hh"
 #include "recurse/simulation/FallingSandSystem.hh"
 #include "recurse/simulation/GhostCells.hh"
@@ -82,11 +83,7 @@ class ReplayExecutorTest : public ::testing::Test {
                     tracker.markSubRegionActive(pos, lx, ly, lz);
     }
 
-    VoxelCell makeMaterial(MaterialId id) {
-        VoxelCell c{};
-        c.materialId = id;
-        return c;
-    }
+    VoxelCell makeMaterial(MaterialId id) { return cellForMaterial(id); }
 
     ReplayExecutor makeExecutor() {
         return ReplayExecutor(txStore, grid, sandSystem, ghosts, tracker, worldSeed, &registry);
@@ -155,7 +152,7 @@ TEST_F(ReplayExecutorTest, SnapshotRoundTrip) {
     const auto* buf = grid.readBuffer(0, 0, 0);
     ASSERT_NE(buf, nullptr);
     for (int i = 0; i < K_CHUNK_VOLUME; ++i) {
-        EXPECT_EQ((*buf)[i].materialId, original[i].materialId) << "Mismatch at cell " << i;
+        EXPECT_EQ(cellMaterialId((*buf)[i]), cellMaterialId(original[i])) << "Mismatch at cell " << i;
     }
 }
 
@@ -187,7 +184,8 @@ TEST_F(ReplayExecutorTest, DeterministicReplayMatchesProduction) {
     const auto* replayBuf = grid.readBuffer(0, 0, 0);
     ASSERT_NE(replayBuf, nullptr);
     for (int i = 0; i < K_CHUNK_VOLUME; ++i) {
-        EXPECT_EQ((*replayBuf)[i].materialId, productionState[i].materialId) << "Mismatch at cell index " << i;
+        EXPECT_EQ(cellMaterialId((*replayBuf)[i]), cellMaterialId(productionState[i]))
+            << "Mismatch at cell index " << i;
     }
 }
 
@@ -213,7 +211,7 @@ TEST_F(ReplayExecutorTest, UserEditsInterleaveCorrectly) {
     ASSERT_EQ(result.status, ReplayStatus::Ok);
 
     VoxelCell cell = grid.readCell(16, 10, 16);
-    EXPECT_EQ(cell.materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(cell), material_ids::STONE);
 }
 
 TEST_F(ReplayExecutorTest, VisualReplayFrameDelivery) {
@@ -308,8 +306,10 @@ TEST_F(ReplayExecutorTest, BoundaryDrainDeterministic) {
     const auto* buf0 = grid.readBuffer(0, 0, 0);
     const auto* buf1 = grid.readBuffer(1, 0, 0);
     for (int i = 0; i < K_CHUNK_VOLUME; ++i) {
-        EXPECT_EQ((*buf0)[i].materialId, state0[i].materialId) << "Non-determinism in chunk (0,0,0) at cell " << i;
-        EXPECT_EQ((*buf1)[i].materialId, state1[i].materialId) << "Non-determinism in chunk (1,0,0) at cell " << i;
+        EXPECT_EQ(cellMaterialId((*buf0)[i]), cellMaterialId(state0[i]))
+            << "Non-determinism in chunk (0,0,0) at cell " << i;
+        EXPECT_EQ(cellMaterialId((*buf1)[i]), cellMaterialId(state1[i]))
+            << "Non-determinism in chunk (1,0,0) at cell " << i;
     }
 }
 
@@ -409,7 +409,7 @@ TEST_F(ReplayExecutorTest, ReplayPlaceEditMatchesLiveExternalEditOutcomeAfterOne
     VoxelCell replayCell = grid.readCell(12, 10, 12);
     ChunkState replayState = tracker.getState({0, 0, 0});
 
-    EXPECT_EQ(replayCell.materialId, liveCell.materialId);
-    EXPECT_EQ(replayCell.flags, liveCell.flags);
+    EXPECT_EQ(cellMaterialId(replayCell), cellMaterialId(liveCell));
+    EXPECT_EQ(replayCell.flags(), liveCell.flags());
     EXPECT_EQ(replayState, liveState);
 }

--- a/tests/unit/persistence/WorldSessionIntegrationTest.cc
+++ b/tests/unit/persistence/WorldSessionIntegrationTest.cc
@@ -1,4 +1,5 @@
 #include "recurse/persistence/WorldSession.hh"
+#include "recurse/simulation/CellAccessors.hh"
 
 #include "fabric/core/AppContext.hh"
 #include "fabric/core/Event.hh"
@@ -507,7 +508,7 @@ class WorldSessionResidentChunkPersistenceTest : public ::testing::Test {
         auto absent = addChunkRef(registry, cx, cy, cz);
         auto generating = transition<Absent, Generating>(absent, registry);
         grid.materializeChunk(cx, cy, cz);
-        grid.writeCell(cx * 32 + 1, cy * 32 + 1, cz * 32 + 1, VoxelCell{material_ids::STONE});
+        grid.writeCell(cx * 32 + 1, cy * 32 + 1, cz * 32 + 1, cellForMaterial(material_ids::STONE));
         grid.syncChunkBuffers(cx, cy, cz);
         transition<Generating, Active>(generating, registry);
     }
@@ -655,11 +656,11 @@ class WorldSessionPersistedDeltaReopenTest : public ::testing::Test {
         session_ = std::move(result).value();
     }
 
-    void generateEditedChunk(int cx, int cy, int cz, uint16_t materialId) {
+    void generateEditedChunk(int cx, int cy, int cz, recurse::simulation::MaterialId materialId) {
         voxelSim_->generateChunk(cx, cy, cz);
         auto& grid = voxelSim_->simulationGrid();
         grid.writeCell(cx * 32 + K_EDIT_OFFSET, cy * 32 + K_EDIT_OFFSET, cz * 32 + K_EDIT_OFFSET,
-                       recurse::simulation::VoxelCell{materialId});
+                       recurse::simulation::cellForMaterial(materialId));
         grid.syncChunkBuffers(cx, cy, cz);
     }
 
@@ -685,9 +686,8 @@ class WorldSessionPersistedDeltaReopenTest : public ::testing::Test {
     }
 
     uint16_t loadedMaterial(int cx, int cy, int cz) const {
-        return voxelSim_->simulationGrid()
-            .readCell(cx * 32 + K_EDIT_OFFSET, cy * 32 + K_EDIT_OFFSET, cz * 32 + K_EDIT_OFFSET)
-            .materialId;
+        return recurse::simulation::cellMaterialId(voxelSim_->simulationGrid().readCell(
+            cx * 32 + K_EDIT_OFFSET, cy * 32 + K_EDIT_OFFSET, cz * 32 + K_EDIT_OFFSET));
     }
 
     fabric::World world_;

--- a/tests/unit/simulation/BoundaryDrainTest.cc
+++ b/tests/unit/simulation/BoundaryDrainTest.cc
@@ -6,11 +6,7 @@ using namespace recurse::simulation;
 
 class BoundaryDrainTest : public ::testing::Test {
   protected:
-    VoxelCell makeMaterial(MaterialId id) {
-        VoxelCell c;
-        c.materialId = id;
-        return c;
-    }
+    VoxelCell makeMaterial(MaterialId id) { return cellForMaterial(id); }
 
     void markAllSubRegions(ChunkActivityTracker& tracker, ChunkCoord pos) {
         for (int lz = 0; lz < K_CHUNK_SIZE; lz += 8)
@@ -100,7 +96,7 @@ TEST_F(BoundaryDrainTest, SortedDrainDeterministic) {
 
     for (size_t chunk = 0; chunk < run1.size(); ++chunk)
         for (size_t i = 0; i < run1[chunk].size(); ++i)
-            EXPECT_EQ(run1[chunk][i].materialId, run2[chunk][i].materialId)
+            EXPECT_EQ(cellMaterialId(run1[chunk][i]), cellMaterialId(run2[chunk][i]))
                 << "Mismatch in chunk " << chunk << " at index " << i;
 }
 
@@ -200,6 +196,6 @@ TEST_F(BoundaryDrainTest, SortedDrainNormalCaseUnchanged) {
     }
 
     // Sand should have crossed the boundary and be at y=31 in lower chunk
-    EXPECT_EQ(sim.grid().readCell(16, 31, 16).materialId, material_ids::SAND);
-    EXPECT_EQ(sim.grid().readCell(16, 32, 16).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(sim.grid().readCell(16, 31, 16)), material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(sim.grid().readCell(16, 32, 16)), material_ids::AIR);
 }

--- a/tests/unit/simulation/CMakeLists.txt
+++ b/tests/unit/simulation/CMakeLists.txt
@@ -16,4 +16,5 @@ target_sources(UnitTests
   BoundaryDrainTest.cc
   MatterStateTest.cc
   ProjectionRuleTableTest.cc
+  CellFactoryTest.cc
 )

--- a/tests/unit/simulation/CellFactoryTest.cc
+++ b/tests/unit/simulation/CellFactoryTest.cc
@@ -1,0 +1,226 @@
+#include "recurse/simulation/CellAccessors.hh"
+#include "recurse/simulation/MaterialRegistry.hh"
+#include "recurse/simulation/MatterState.hh"
+#include "recurse/simulation/ProjectionRuleTable.hh"
+#include "recurse/simulation/VoxelMaterial.hh"
+
+#include <gtest/gtest.h>
+
+using namespace recurse::simulation;
+
+// -- phaseFromMoveType -------------------------------------------------------
+
+TEST(CellFactoryTest, PhaseFromMoveTypeStatic) {
+    EXPECT_EQ(phaseFromMoveType(MoveType::Static), Phase::Solid);
+}
+
+TEST(CellFactoryTest, PhaseFromMoveTypePowder) {
+    EXPECT_EQ(phaseFromMoveType(MoveType::Powder), Phase::Powder);
+}
+
+TEST(CellFactoryTest, PhaseFromMoveTypeLiquid) {
+    EXPECT_EQ(phaseFromMoveType(MoveType::Liquid), Phase::Liquid);
+}
+
+TEST(CellFactoryTest, PhaseFromMoveTypeGas) {
+    EXPECT_EQ(phaseFromMoveType(MoveType::Gas), Phase::Gas);
+}
+
+// -- makeCell ----------------------------------------------------------------
+
+TEST(CellFactoryTest, MakeCellSetsEssenceIdx) {
+    auto cell = makeCell(42, Phase::Solid);
+    EXPECT_EQ(cell.essenceIdx, 42);
+}
+
+TEST(CellFactoryTest, MakeCellSetsPhase) {
+    auto cell = makeCell(1, Phase::Liquid);
+    EXPECT_EQ(cell.phase(), Phase::Liquid);
+}
+
+TEST(CellFactoryTest, MakeCellSetsDisplacementRank) {
+    auto cell = makeCell(1, Phase::Powder, 130);
+    EXPECT_EQ(cell.displacementRank, 130);
+}
+
+TEST(CellFactoryTest, MakeCellSetsFlags) {
+    auto cell = makeCell(1, Phase::Solid, 0, 0x1F);
+    EXPECT_EQ(cell.flags(), 0x1F);
+}
+
+TEST(CellFactoryTest, MakeCellDefaultDisplacementRankIsZero) {
+    auto cell = makeCell(1, Phase::Solid);
+    EXPECT_EQ(cell.displacementRank, 0);
+}
+
+TEST(CellFactoryTest, MakeCellDefaultFlagsIsZero) {
+    auto cell = makeCell(1, Phase::Solid);
+    EXPECT_EQ(cell.flags(), 0);
+}
+
+TEST(CellFactoryTest, MakeCellSpareIsZero) {
+    auto cell = makeCell(5, Phase::Gas, 100, 0x0A);
+    EXPECT_EQ(cell.spare, 0);
+}
+
+// -- emptyCell ---------------------------------------------------------------
+
+TEST(CellFactoryTest, EmptyCellIsAllZero) {
+    auto cell = emptyCell();
+    EXPECT_EQ(cell.essenceIdx, 0);
+    EXPECT_EQ(cell.displacementRank, 0);
+    EXPECT_EQ(cell.phaseAndFlags, 0);
+    EXPECT_EQ(cell.spare, 0);
+}
+
+TEST(CellFactoryTest, EmptyCellPhaseIsEmpty) {
+    auto cell = emptyCell();
+    EXPECT_EQ(cell.phase(), Phase::Empty);
+}
+
+TEST(CellFactoryTest, EmptyCellIsEmptyViaAccessor) {
+    auto cell = emptyCell();
+    EXPECT_TRUE(isEmpty(cell));
+    EXPECT_FALSE(isOccupied(cell));
+}
+
+// -- makeCellFromMaterial ----------------------------------------------------
+
+class CellFactoryMaterialTest : public ::testing::Test {
+  protected:
+    MaterialRegistry registry;
+};
+
+TEST_F(CellFactoryMaterialTest, AirIsPhaseEmpty) {
+    auto cell = makeCellFromMaterial(material_ids::AIR, registry);
+    EXPECT_EQ(cell.phase(), Phase::Empty);
+    EXPECT_EQ(cell.essenceIdx, 0);
+    EXPECT_EQ(cell.displacementRank, registry.get(material_ids::AIR).density);
+}
+
+TEST_F(CellFactoryMaterialTest, StoneIsPhaseSolid) {
+    auto cell = makeCellFromMaterial(material_ids::STONE, registry);
+    EXPECT_EQ(cell.phase(), Phase::Solid);
+    EXPECT_EQ(cell.essenceIdx, static_cast<uint8_t>(material_ids::STONE));
+    EXPECT_EQ(cell.displacementRank, registry.get(material_ids::STONE).density);
+}
+
+TEST_F(CellFactoryMaterialTest, WaterIsPhaseLiquid) {
+    auto cell = makeCellFromMaterial(material_ids::WATER, registry);
+    EXPECT_EQ(cell.phase(), Phase::Liquid);
+    EXPECT_EQ(cell.essenceIdx, static_cast<uint8_t>(material_ids::WATER));
+    EXPECT_EQ(cell.displacementRank, registry.get(material_ids::WATER).density);
+}
+
+TEST_F(CellFactoryMaterialTest, SandIsPhasePowder) {
+    auto cell = makeCellFromMaterial(material_ids::SAND, registry);
+    EXPECT_EQ(cell.phase(), Phase::Powder);
+    EXPECT_EQ(cell.essenceIdx, static_cast<uint8_t>(material_ids::SAND));
+    EXPECT_EQ(cell.displacementRank, registry.get(material_ids::SAND).density);
+}
+
+TEST_F(CellFactoryMaterialTest, GravelIsPhasePowder) {
+    auto cell = makeCellFromMaterial(material_ids::GRAVEL, registry);
+    EXPECT_EQ(cell.phase(), Phase::Powder);
+    EXPECT_EQ(cell.essenceIdx, static_cast<uint8_t>(material_ids::GRAVEL));
+    EXPECT_EQ(cell.displacementRank, registry.get(material_ids::GRAVEL).density);
+}
+
+TEST_F(CellFactoryMaterialTest, DirtIsPhaseSolid) {
+    auto cell = makeCellFromMaterial(material_ids::DIRT, registry);
+    EXPECT_EQ(cell.phase(), Phase::Solid);
+    EXPECT_EQ(cell.essenceIdx, static_cast<uint8_t>(material_ids::DIRT));
+    EXPECT_EQ(cell.displacementRank, registry.get(material_ids::DIRT).density);
+}
+
+TEST_F(CellFactoryMaterialTest, FlagsPassedThrough) {
+    auto cell = makeCellFromMaterial(material_ids::STONE, registry, 0x0B);
+    EXPECT_EQ(cell.flags(), 0x0B);
+    EXPECT_EQ(cell.phase(), Phase::Solid);
+}
+
+// -- Round-trip tests --------------------------------------------------------
+
+TEST(CellFactoryTest, MakeCellPhaseRoundTrip) {
+    const Phase phases[] = {Phase::Empty, Phase::Solid, Phase::Powder, Phase::Liquid, Phase::Gas};
+    for (auto p : phases) {
+        auto cell = makeCell(0, p);
+        EXPECT_EQ(cell.phase(), p);
+    }
+}
+
+TEST(CellFactoryTest, MakeCellFlagsRoundTrip) {
+    for (uint8_t f = 0; f <= 0x1F; ++f) {
+        auto cell = makeCell(0, Phase::Solid, 0, f);
+        EXPECT_EQ(cell.flags(), f);
+    }
+}
+
+TEST(CellFactoryTest, MakeCellPhaseAndFlagsIndependent) {
+    auto cell = makeCell(7, Phase::Gas, 200, 0x15);
+    EXPECT_EQ(cell.essenceIdx, 7);
+    EXPECT_EQ(cell.phase(), Phase::Gas);
+    EXPECT_EQ(cell.displacementRank, 200);
+    EXPECT_EQ(cell.flags(), 0x15);
+    EXPECT_EQ(cell.spare, 0);
+}
+
+// -- Projection-aware accessors (MatterState) --------------------------------
+
+TEST(ProjectionAccessorTest, CellMaterialIdEmptyReturnsAir) {
+    auto cell = emptyCell();
+    EXPECT_EQ(cellMaterialId(cell), material_ids::AIR);
+}
+
+TEST(ProjectionAccessorTest, CellMaterialIdSandReturns3) {
+    auto cell = makeCell(static_cast<uint8_t>(material_ids::SAND), Phase::Powder);
+    EXPECT_EQ(cellMaterialId(cell), material_ids::SAND);
+}
+
+TEST(ProjectionAccessorTest, CellMaterialIdStoneReturns1) {
+    auto cell = makeCell(static_cast<uint8_t>(material_ids::STONE), Phase::Solid);
+    EXPECT_EQ(cellMaterialId(cell), material_ids::STONE);
+}
+
+TEST(ProjectionAccessorTest, MergeKeyEmptyReturnsEmpty) {
+    auto cell = emptyCell();
+    EXPECT_EQ(mergeKey(cell), K_MERGE_KEY_EMPTY);
+}
+
+TEST(ProjectionAccessorTest, MergeKeyReturnsEssenceIdx) {
+    auto cell = makeCell(static_cast<uint8_t>(material_ids::WATER), Phase::Liquid);
+    EXPECT_EQ(mergeKey(cell), static_cast<MergeKey>(material_ids::WATER));
+}
+
+TEST(ProjectionAccessorTest, SemanticPrioritySandReturns4) {
+    MatterState cell;
+    cell.essenceIdx = static_cast<uint8_t>(material_ids::SAND);
+    cell.setPhase(Phase::Powder);
+    EXPECT_EQ(materialSemanticPriority(cell), 4);
+}
+
+TEST(ProjectionAccessorTest, SemanticPriorityStoneReturns1) {
+    MatterState cell;
+    cell.essenceIdx = static_cast<uint8_t>(material_ids::STONE);
+    cell.setPhase(Phase::Solid);
+    EXPECT_EQ(materialSemanticPriority(cell), 1);
+}
+
+TEST(ProjectionAccessorTest, SemanticPriorityAirReturns0) {
+    MatterState cell{};
+    EXPECT_EQ(materialSemanticPriority(cell), 0);
+}
+
+TEST(ProjectionAccessorTest, TableCellMaterialIdMatchesNonTable) {
+    ProjectionRuleTable table;
+    MatterState cell;
+    cell.essenceIdx = static_cast<uint8_t>(material_ids::SAND);
+    cell.setPhase(Phase::Powder);
+    EXPECT_EQ(cellMaterialId(table, cell), cellMaterialId(cell));
+}
+
+TEST(ProjectionAccessorTest, TableCellMaterialIdEmptyMatchesNonTable) {
+    ProjectionRuleTable table;
+    MatterState cell{};
+    EXPECT_EQ(cellMaterialId(table, cell), cellMaterialId(cell));
+}

--- a/tests/unit/simulation/ChunkRegistryTest.cc
+++ b/tests/unit/simulation/ChunkRegistryTest.cc
@@ -1,4 +1,5 @@
 #include "recurse/simulation/ChunkRegistry.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkState.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
@@ -14,10 +15,10 @@ class ChunkRegistryTest : public ::testing::Test {
 // 1. addChunk returns reference; second call returns same chunk (no duplicate)
 TEST_F(ChunkRegistryTest, AddChunkIdempotent) {
     auto& first = registry.addChunk(0, 0, 0);
-    first.simBuffers.fillValue.materialId = material_ids::STONE;
+    first.simBuffers.fillValue = cellForMaterial(material_ids::STONE);
 
     auto& second = registry.addChunk(0, 0, 0);
-    EXPECT_EQ(second.simBuffers.fillValue.materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(second.simBuffers.fillValue), material_ids::STONE);
     EXPECT_EQ(&first, &second);
     EXPECT_EQ(registry.chunkCount(), 1u);
 }
@@ -147,12 +148,12 @@ TEST_F(ChunkRegistryTest, ChunkSlotMaterialize) {
 // 11. Materialized buffers are filled with fillValue
 TEST_F(ChunkRegistryTest, MaterializePreservesFillValue) {
     auto& slot = registry.addChunk(0, 0, 0);
-    slot.simBuffers.fillValue.materialId = material_ids::STONE;
+    slot.simBuffers.fillValue = cellForMaterial(material_ids::STONE);
     slot.materialize();
 
     for (int b = 0; b < ChunkBuffers::K_COUNT; ++b) {
         for (size_t i = 0; i < K_CHUNK_VOLUME; ++i) {
-            EXPECT_EQ((*slot.simBuffers.buffers[b])[i].materialId, material_ids::STONE)
+            EXPECT_EQ(cellMaterialId((*slot.simBuffers.buffers[b])[i]), material_ids::STONE)
                 << "Buffer " << b << ", index " << i;
         }
     }
@@ -295,16 +296,16 @@ TEST_F(ChunkRegistryTest, SyncChunkBuffersCopiesSingleChunk) {
     grid.materializeChunk(1, 0, 0);
 
     VoxelCell sand;
-    sand.materialId = material_ids::SAND;
+    sand = cellForMaterial(material_ids::SAND);
     grid.writeCell(0, 0, 0, sand);
 
     grid.syncChunkBuffers(0, 0, 0);
 
     // Chunk A read buffer should now have Sand
-    EXPECT_EQ(grid.readCell(0, 0, 0).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 0, 0)), material_ids::SAND);
 
     // Chunk B read buffer should still be Air (untouched)
-    EXPECT_EQ(grid.readCell(32, 0, 0).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(32, 0, 0)), material_ids::AIR);
 }
 
 // 25. syncChunkBuffers is a no-op for unmaterialized chunks

--- a/tests/unit/simulation/FallingSandGravityTest.cc
+++ b/tests/unit/simulation/FallingSandGravityTest.cc
@@ -1,3 +1,4 @@
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkActivityTracker.hh"
 #include "recurse/simulation/FallingSandSystem.hh"
 #include "recurse/simulation/GhostCells.hh"
@@ -32,11 +33,7 @@ class FallingSandGravityTest : public ::testing::Test {
                     tracker.markSubRegionActive(ChunkCoord{0, 0, 0}, lx, ly, lz);
     }
 
-    VoxelCell makeMaterial(MaterialId id) {
-        VoxelCell c;
-        c.materialId = id;
-        return c;
-    }
+    VoxelCell makeMaterial(MaterialId id) { return cellForMaterial(id); }
 
     void placeCellAndAdvance(int wx, int wy, int wz, VoxelCell cell) {
         grid.writeCell(wx, wy, wz, cell);
@@ -56,8 +53,8 @@ TEST_F(FallingSandGravityTest, SandFallsOnePerTick) {
 
     runGravityTick(ChunkCoord{0, 0, 0}, 0);
 
-    EXPECT_EQ(grid.readCell(16, 30, 16).materialId, material_ids::SAND);
-    EXPECT_EQ(grid.readCell(16, 31, 16).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 30, 16)), material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 31, 16)), material_ids::AIR);
 }
 
 // 2. Sand falls to ground (stone floor)
@@ -75,8 +72,8 @@ TEST_F(FallingSandGravityTest, SandFallsToGround) {
     for (uint64_t f = 0; f < 10; ++f)
         runGravityTick(ChunkCoord{0, 0, 0}, f);
 
-    EXPECT_EQ(grid.readCell(16, 1, 16).materialId, material_ids::SAND);
-    EXPECT_EQ(grid.readCell(16, 0, 16).materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 1, 16)), material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 0, 16)), material_ids::STONE);
 }
 
 // 3. Two sand grains stack (contained column prevents diagonal cascade)
@@ -102,8 +99,8 @@ TEST_F(FallingSandGravityTest, SandStacksOnSand) {
     for (uint64_t f = 0; f < 15; ++f)
         runGravityTick(ChunkCoord{0, 0, 0}, f);
 
-    EXPECT_EQ(grid.readCell(16, 1, 16).materialId, material_ids::SAND);
-    EXPECT_EQ(grid.readCell(16, 2, 16).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 1, 16)), material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 2, 16)), material_ids::SAND);
 }
 
 // 4. Powder cascades diagonally off a pillar
@@ -120,7 +117,7 @@ TEST_F(FallingSandGravityTest, PowderCascadeDiagonal) {
         runGravityTick(ChunkCoord{0, 0, 0}, f);
 
     // Sand should NOT be at (16,1,16) anymore -- it cascaded
-    EXPECT_NE(grid.readCell(16, 1, 16).materialId, material_ids::SAND);
+    EXPECT_NE(cellMaterialId(grid.readCell(16, 1, 16)), material_ids::SAND);
 }
 
 // 5. Stone does not fall
@@ -130,7 +127,7 @@ TEST_F(FallingSandGravityTest, StoneDoesNotFall) {
     for (uint64_t f = 0; f < 100; ++f)
         runGravityTick(ChunkCoord{0, 0, 0}, f);
 
-    EXPECT_EQ(grid.readCell(16, 16, 16).materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 16, 16)), material_ids::STONE);
 }
 
 // 6. Density ordering: gravel sinks below sand (contained column)
@@ -157,8 +154,8 @@ TEST_F(FallingSandGravityTest, DensityOrdering) {
         runGravityTick(ChunkCoord{0, 0, 0}, f);
 
     // Gravel (density 170) should be below sand (density 130)
-    EXPECT_EQ(grid.readCell(16, 1, 16).materialId, material_ids::GRAVEL);
-    EXPECT_EQ(grid.readCell(16, 2, 16).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 1, 16)), material_ids::GRAVEL);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 2, 16)), material_ids::SAND);
 }
 
 // 7. Direction alternation produces roughly symmetric piles
@@ -182,12 +179,12 @@ TEST_F(FallingSandGravityTest, DirectionAlternationSymmetry) {
     for (int x = 0; x < 16; ++x)
         for (int y = 0; y < K_CHUNK_SIZE; ++y)
             for (int z = 0; z < K_CHUNK_SIZE; ++z)
-                if (grid.readCell(x, y, z).materialId == material_ids::SAND)
+                if (cellMaterialId(grid.readCell(x, y, z)) == material_ids::SAND)
                     ++leftCount;
     for (int x = 17; x < K_CHUNK_SIZE; ++x)
         for (int y = 0; y < K_CHUNK_SIZE; ++y)
             for (int z = 0; z < K_CHUNK_SIZE; ++z)
-                if (grid.readCell(x, y, z).materialId == material_ids::SAND)
+                if (cellMaterialId(grid.readCell(x, y, z)) == material_ids::SAND)
                     ++rightCount;
 
     // Both sides should have at least some sand (rough symmetry)
@@ -225,8 +222,8 @@ TEST_F(FallingSandGravityTest, CrossChunkFalling) {
     boundaryWrites.clear();
     grid.advanceEpoch();
 
-    EXPECT_EQ(grid.readCell(16, 31, 16).materialId, material_ids::SAND);
-    EXPECT_EQ(grid.readCell(16, 32, 16).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 31, 16)), material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 32, 16)), material_ids::AIR);
 }
 
 // 9. No movement -> simulateGravity returns false (caller handles sleep)
@@ -248,21 +245,21 @@ TEST_F(FallingSandGravityTest, NoMovementSleepsChunk) {
     EXPECT_FALSE(changed) << "All-stone chunk should have no gravity movement";
 }
 
-// 10. Gravity preserves essenceIdx
+// 10. Gravity preserves spare byte
 TEST_F(FallingSandGravityTest, GravityPreservesEssenceIdx) {
     VoxelCell sand;
-    sand.materialId = material_ids::SAND;
-    sand.essenceIdx = 42;
+    sand = cellForMaterial(material_ids::SAND);
+    sand.spare = 42;
     placeCellAndAdvance(16, 31, 16, sand);
 
     runGravityTick(ChunkCoord{0, 0, 0}, 0);
 
     VoxelCell fallen = grid.readCell(16, 30, 16);
-    EXPECT_EQ(fallen.materialId, material_ids::SAND);
-    EXPECT_EQ(fallen.essenceIdx, 42);
+    EXPECT_EQ(cellMaterialId(fallen), material_ids::SAND);
+    EXPECT_EQ(fallen.spare, 42);
 }
 
-// 11. Displacement swap preserves essenceIdx on both cells
+// 11. Displacement swap preserves spare byte on both cells
 TEST_F(FallingSandGravityTest, DisplacementSwapPreservesEssenceIdx) {
     for (int x = 0; x < K_CHUNK_SIZE; ++x)
         for (int z = 0; z < K_CHUNK_SIZE; ++z)
@@ -276,13 +273,13 @@ TEST_F(FallingSandGravityTest, DisplacementSwapPreservesEssenceIdx) {
     grid.advanceEpoch();
 
     VoxelCell sand;
-    sand.materialId = material_ids::SAND;
-    sand.essenceIdx = 10;
+    sand = cellForMaterial(material_ids::SAND);
+    sand.spare = 10;
     grid.writeCell(16, 1, 16, sand);
 
     VoxelCell gravel;
-    gravel.materialId = material_ids::GRAVEL;
-    gravel.essenceIdx = 20;
+    gravel = cellForMaterial(material_ids::GRAVEL);
+    gravel.spare = 20;
     grid.writeCell(16, 2, 16, gravel);
     grid.advanceEpoch();
 
@@ -291,10 +288,10 @@ TEST_F(FallingSandGravityTest, DisplacementSwapPreservesEssenceIdx) {
 
     VoxelCell bottom = grid.readCell(16, 1, 16);
     VoxelCell top = grid.readCell(16, 2, 16);
-    EXPECT_EQ(bottom.materialId, material_ids::GRAVEL);
-    EXPECT_EQ(bottom.essenceIdx, 20);
-    EXPECT_EQ(top.materialId, material_ids::SAND);
-    EXPECT_EQ(top.essenceIdx, 10);
+    EXPECT_EQ(cellMaterialId(bottom), material_ids::GRAVEL);
+    EXPECT_EQ(bottom.spare, 20);
+    EXPECT_EQ(cellMaterialId(top), material_ids::SAND);
+    EXPECT_EQ(top.spare, 10);
 }
 
 // 12. Performance: 50% powder chunk simulates in < 2ms

--- a/tests/unit/simulation/FallingSandLiquidTest.cc
+++ b/tests/unit/simulation/FallingSandLiquidTest.cc
@@ -1,3 +1,4 @@
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkActivityTracker.hh"
 #include "recurse/simulation/FallingSandSystem.hh"
 #include "recurse/simulation/GhostCells.hh"
@@ -31,11 +32,7 @@ class FallingSandLiquidTest : public ::testing::Test {
                     tracker.markSubRegionActive(ChunkCoord{0, 0, 0}, lx, ly, lz);
     }
 
-    VoxelCell makeMaterial(MaterialId id) {
-        VoxelCell c;
-        c.materialId = id;
-        return c;
-    }
+    VoxelCell makeMaterial(MaterialId id) { return cellForMaterial(id); }
 
     void runLiquidTick(ChunkCoord pos, uint64_t frame) {
         ghosts.syncGhostCells(pos, grid);
@@ -77,7 +74,7 @@ class FallingSandLiquidTest : public ::testing::Test {
         for (int x = xmin; x <= xmax; ++x)
             for (int y = ymin; y <= ymax; ++y)
                 for (int z = zmin; z <= zmax; ++z)
-                    if (grid.readCell(x, y, z).materialId == id)
+                    if (cellMaterialId(grid.readCell(x, y, z)) == id)
                         ++count;
         return count;
     }
@@ -90,8 +87,8 @@ TEST_F(FallingSandLiquidTest, WaterFallsInAir) {
 
     runLiquidTick(ChunkCoord{0, 0, 0}, 0);
 
-    EXPECT_EQ(grid.readCell(16, 9, 16).materialId, material_ids::WATER);
-    EXPECT_EQ(grid.readCell(16, 10, 16).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 9, 16)), material_ids::WATER);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 10, 16)), material_ids::AIR);
 }
 
 // 2. Water spreads horizontally on flat surface
@@ -108,12 +105,12 @@ TEST_F(FallingSandLiquidTest, WaterFlowsHorizontally) {
     // With immediate-mode reads, water cascades multiple cells per tick
     // (scan sees its own writes). After 10 ticks, water is far from origin.
     // Verify: (1) origin is empty, (2) water exists somewhere at y=1.
-    EXPECT_NE(grid.readCell(16, 1, 16).materialId, material_ids::WATER) << "Water should have moved from origin";
+    EXPECT_NE(cellMaterialId(grid.readCell(16, 1, 16)), material_ids::WATER) << "Water should have moved from origin";
 
     bool anyWaterAtY1 = false;
     for (int x = 0; x < K_CHUNK_SIZE && !anyWaterAtY1; ++x)
         for (int z = 0; z < K_CHUNK_SIZE && !anyWaterAtY1; ++z)
-            if (grid.readCell(x, 1, z).materialId == material_ids::WATER)
+            if (cellMaterialId(grid.readCell(x, 1, z)) == material_ids::WATER)
                 anyWaterAtY1 = true;
     EXPECT_TRUE(anyWaterAtY1) << "Water should still exist at y=1 level";
 }
@@ -243,7 +240,7 @@ TEST_F(FallingSandLiquidTest, CrossChunkHorizontalFlow) {
     }
 
     // Water should have flowed into chunk(-1,0,0), i.e., world x=-1
-    bool flowedLeft = grid.readCell(-1, 1, 16).materialId == material_ids::WATER;
+    bool flowedLeft = cellMaterialId(grid.readCell(-1, 1, 16)) == material_ids::WATER;
     // Or it might still be at x=0 if it flowed other directions first
     int totalWater = countMaterial(material_ids::WATER, -2, 2, 1, 1, 15, 17);
     EXPECT_GE(totalWater, 1) << "Water should exist near the boundary";
@@ -263,7 +260,7 @@ TEST_F(FallingSandLiquidTest, ViscosityLimitsFlowRate) {
     bool foundFarWater = false;
     for (int x = 0; x < K_CHUNK_SIZE; ++x) {
         for (int z = 0; z < K_CHUNK_SIZE; ++z) {
-            if (grid.readCell(x, 1, z).materialId == material_ids::WATER) {
+            if (cellMaterialId(grid.readCell(x, 1, z)) == material_ids::WATER) {
                 int dist = std::abs(x - 16) + std::abs(z - 16);
                 if (dist > 1)
                     foundFarWater = true;
@@ -313,23 +310,23 @@ TEST_F(FallingSandLiquidTest, WaterDoesNotDisplaceSolids) {
         runChunkTick(ChunkCoord{0, 0, 0}, f);
     }
 
-    EXPECT_EQ(grid.readCell(16, 1, 16).materialId, material_ids::STONE);
-    EXPECT_EQ(grid.readCell(16, 0, 16).materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 1, 16)), material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 0, 16)), material_ids::STONE);
 }
 
-// 10. Liquid flow preserves essenceIdx
+// 10. Liquid flow preserves spare byte
 TEST_F(FallingSandLiquidTest, LiquidFlowPreservesEssenceIdx) {
     VoxelCell water;
-    water.materialId = material_ids::WATER;
-    water.essenceIdx = 7;
+    water = cellForMaterial(material_ids::WATER);
+    water.spare = 7;
     grid.writeCell(16, 10, 16, water);
     grid.advanceEpoch();
 
     runLiquidTick(ChunkCoord{0, 0, 0}, 0);
 
     VoxelCell fallen = grid.readCell(16, 9, 16);
-    EXPECT_EQ(fallen.materialId, material_ids::WATER);
-    EXPECT_EQ(fallen.essenceIdx, 7);
+    EXPECT_EQ(cellMaterialId(fallen), material_ids::WATER);
+    EXPECT_EQ(fallen.spare, 7);
 }
 
 // 11. Performance: 10K liquid cells under 3ms

--- a/tests/unit/simulation/FallingSandPhysicsChangeTest.cc
+++ b/tests/unit/simulation/FallingSandPhysicsChangeTest.cc
@@ -1,3 +1,4 @@
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkActivityTracker.hh"
 #include "recurse/simulation/FallingSandSystem.hh"
 #include "recurse/simulation/GhostCells.hh"
@@ -31,11 +32,7 @@ class FallingSandPhysicsChangeTest : public ::testing::Test {
                     tracker.markSubRegionActive(ChunkCoord{0, 0, 0}, lx, ly, lz);
     }
 
-    VoxelCell makeMaterial(MaterialId id) {
-        VoxelCell c;
-        c.materialId = id;
-        return c;
-    }
+    VoxelCell makeMaterial(MaterialId id) { return cellForMaterial(id); }
 
     void placeCellAndAdvance(int wx, int wy, int wz, VoxelCell cell) {
         grid.writeCell(wx, wy, wz, cell);
@@ -177,7 +174,7 @@ TEST_F(FallingSandPhysicsChangeTest, MatterConservationWithTracking) {
         for (int z = 0; z < K_CHUNK_SIZE; ++z)
             for (int y = 0; y < K_CHUNK_SIZE; ++y)
                 for (int x = 0; x < K_CHUNK_SIZE; ++x)
-                    if (g.readCell(x, y, z).materialId == material_ids::SAND)
+                    if (cellMaterialId(g.readCell(x, y, z)) == material_ids::SAND)
                         ++count;
         return count;
     };

--- a/tests/unit/simulation/GhostCellsTest.cc
+++ b/tests/unit/simulation/GhostCellsTest.cc
@@ -1,4 +1,5 @@
 #include "recurse/simulation/GhostCells.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 #include <gtest/gtest.h>
@@ -17,19 +18,19 @@ class GhostCellsTest : public ::testing::Test {
 
     VoxelCell makeSand() {
         VoxelCell c;
-        c.materialId = material_ids::SAND;
+        c = cellForMaterial(material_ids::SAND);
         return c;
     }
 
     VoxelCell makeStone() {
         VoxelCell c;
-        c.materialId = material_ids::STONE;
+        c = cellForMaterial(material_ids::STONE);
         return c;
     }
 
     VoxelCell makeWater() {
         VoxelCell c;
-        c.materialId = material_ids::WATER;
+        c = cellForMaterial(material_ids::WATER);
         return c;
     }
 };
@@ -50,7 +51,7 @@ TEST_F(GhostCellsTest, SyncCopiesNeighborBoundary) {
 
     // +X face, u=ly=0, v=lz=0 should be Sand
     VoxelCell ghost = ghosts.getStore(origin).get(Face::PosX, 0, 0);
-    EXPECT_EQ(ghost.materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(ghost), material_ids::SAND);
 }
 
 // 2. Ghost reads from read buffer, not write buffer
@@ -71,7 +72,7 @@ TEST_F(GhostCellsTest, GhostReflectsReadBuffer) {
 
     // Should see Stone (read buffer), not Sand (write buffer)
     VoxelCell ghost = ghosts.getStore(origin).get(Face::PosX, 0, 0);
-    EXPECT_EQ(ghost.materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(ghost), material_ids::STONE);
 }
 
 // 3. Missing neighbor returns Air
@@ -83,7 +84,7 @@ TEST_F(GhostCellsTest, MissingNeighborReturnsAir) {
     ghosts.syncGhostCells(origin, grid);
 
     VoxelCell ghost = ghosts.getStore(origin).get(Face::PosX, 5, 5);
-    EXPECT_EQ(ghost.materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(ghost), material_ids::AIR);
 }
 
 // 4. All 6 faces copy correct neighbor slices
@@ -97,51 +98,51 @@ TEST_F(GhostCellsTest, AllSixFacesCorrect) {
     // +X: neighbor(1,0,0) local(0,5,5) = world(32,5,5)
     grid.fillChunk(1, 0, 0, VoxelCell{});
     VoxelCell c1;
-    c1.materialId = material_ids::SAND;
+    c1 = cellForMaterial(material_ids::SAND);
     grid.writeCell(32, 5, 5, c1);
 
     // -X: neighbor(-1,0,0) local(31,5,5) = world(-1,5,5)
     grid.fillChunk(-1, 0, 0, VoxelCell{});
     VoxelCell c2;
-    c2.materialId = material_ids::STONE;
+    c2 = cellForMaterial(material_ids::STONE);
     grid.writeCell(-1, 5, 5, c2);
 
     // +Y: neighbor(0,1,0) local(5,0,5) = world(5,32,5)
     grid.fillChunk(0, 1, 0, VoxelCell{});
     VoxelCell c3;
-    c3.materialId = material_ids::DIRT;
+    c3 = cellForMaterial(material_ids::DIRT);
     grid.writeCell(5, 32, 5, c3);
 
     // -Y: neighbor(0,-1,0) local(5,31,5) = world(5,-1,5)
     grid.fillChunk(0, -1, 0, VoxelCell{});
     VoxelCell c4;
-    c4.materialId = material_ids::WATER;
+    c4 = cellForMaterial(material_ids::WATER);
     grid.writeCell(5, -1, 5, c4);
 
     // +Z: neighbor(0,0,1) local(5,5,0) = world(5,5,32)
     grid.fillChunk(0, 0, 1, VoxelCell{});
     VoxelCell c5;
-    c5.materialId = material_ids::GRAVEL;
+    c5 = cellForMaterial(material_ids::GRAVEL);
     grid.writeCell(5, 5, 32, c5);
 
     // -Z: neighbor(0,0,-1) local(5,5,31) = world(5,5,-1)
     grid.fillChunk(0, 0, -1, VoxelCell{});
     VoxelCell c6;
-    c6.materialId = material_ids::SAND;
-    c6.flags = voxel_flags::FREE_FALL; // distinguish from +X sand
+    c6 = cellForMaterial(material_ids::SAND);
+    c6.setFlags(voxel_flags::FREE_FALL); // distinguish from +X sand
     grid.writeCell(5, 5, -1, c6);
 
     grid.advanceEpoch();
     ghosts.syncGhostCells(origin, grid);
 
     auto& store = ghosts.getStore(origin);
-    EXPECT_EQ(store.get(Face::PosX, 5, 5).materialId, material_ids::SAND);
-    EXPECT_EQ(store.get(Face::NegX, 5, 5).materialId, material_ids::STONE);
-    EXPECT_EQ(store.get(Face::PosY, 5, 5).materialId, material_ids::DIRT);
-    EXPECT_EQ(store.get(Face::NegY, 5, 5).materialId, material_ids::WATER);
-    EXPECT_EQ(store.get(Face::PosZ, 5, 5).materialId, material_ids::GRAVEL);
-    EXPECT_EQ(store.get(Face::NegZ, 5, 5).materialId, material_ids::SAND);
-    EXPECT_EQ(store.get(Face::NegZ, 5, 5).flags, voxel_flags::FREE_FALL);
+    EXPECT_EQ(cellMaterialId(store.get(Face::PosX, 5, 5)), material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(store.get(Face::NegX, 5, 5)), material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(store.get(Face::PosY, 5, 5)), material_ids::DIRT);
+    EXPECT_EQ(cellMaterialId(store.get(Face::NegY, 5, 5)), material_ids::WATER);
+    EXPECT_EQ(cellMaterialId(store.get(Face::PosZ, 5, 5)), material_ids::GRAVEL);
+    EXPECT_EQ(cellMaterialId(store.get(Face::NegZ, 5, 5)), material_ids::SAND);
+    EXPECT_EQ(store.get(Face::NegZ, 5, 5).flags(), voxel_flags::FREE_FALL);
 }
 
 // 5. Resync after modification picks up new values
@@ -155,13 +156,13 @@ TEST_F(GhostCellsTest, ResyncUpdatesValues) {
     grid.writeCell(32, 0, 0, makeStone());
     grid.advanceEpoch();
     ghosts.syncGhostCells(origin, grid);
-    EXPECT_EQ(ghosts.getStore(origin).get(Face::PosX, 0, 0).materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(ghosts.getStore(origin).get(Face::PosX, 0, 0)), material_ids::STONE);
 
     // Update: sand at same position
     grid.writeCell(32, 0, 0, makeSand());
     grid.advanceEpoch();
     ghosts.syncGhostCells(origin, grid);
-    EXPECT_EQ(ghosts.getStore(origin).get(Face::PosX, 0, 0).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(ghosts.getStore(origin).get(Face::PosX, 0, 0)), material_ids::SAND);
 }
 
 // 6. Ghost cell count: 6 * 1024 = 6144
@@ -193,11 +194,11 @@ TEST_F(GhostCellsTest, ReadGhostMapsOutOfBounds) {
 
     // lx=-1 -> NegX face, u=ly=5, v=lz=5
     VoxelCell negX = ghosts.readGhost(origin, -1, 5, 5);
-    EXPECT_EQ(negX.materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(negX), material_ids::SAND);
 
     // lx=32 -> PosX face, u=ly=5, v=lz=5
     VoxelCell posX = ghosts.readGhost(origin, 32, 5, 5);
-    EXPECT_EQ(posX.materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(posX), material_ids::STONE);
 }
 
 // 8. Negative chunk coordinates work correctly
@@ -215,9 +216,9 @@ TEST_F(GhostCellsTest, NegativeChunkCoordinates) {
     ghosts.syncGhostCells(origin, grid);
 
     VoxelCell ghost = ghosts.getStore(origin).get(Face::PosX, 0, 0);
-    EXPECT_EQ(ghost.materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(ghost), material_ids::SAND);
 
     // Also check via readGhost
     VoxelCell readG = ghosts.readGhost(origin, 32, 0, 0);
-    EXPECT_EQ(readG.materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(readG), material_ids::SAND);
 }

--- a/tests/unit/simulation/MaterialRegistryTest.cc
+++ b/tests/unit/simulation/MaterialRegistryTest.cc
@@ -1,4 +1,5 @@
 #include "recurse/simulation/MaterialRegistry.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/EssenceColor.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 #include "recurse/simulation/VoxelSemanticView.hh"
@@ -15,8 +16,8 @@ TEST(VoxelCellTest, SizeIs4Bytes) {
 
 TEST(VoxelCellTest, DefaultIsAir) {
     VoxelCell cell;
-    EXPECT_EQ(cell.materialId, material_ids::AIR);
-    EXPECT_EQ(cell.flags, voxel_flags::NONE);
+    EXPECT_EQ(cell.phase(), Phase::Empty);
+    EXPECT_EQ(cell.flags(), voxel_flags::NONE);
 }
 
 class MaterialRegistryTest : public ::testing::Test {
@@ -133,17 +134,19 @@ TEST_F(MaterialRegistryTest, ResolveVoxelSemanticsUsesChunkLocalPaletteAsOptiona
     MaterialSemanticRegistry semantics(registry);
     recurse::EssencePalette palette;
 
-    const auto index = palette.addEntryRaw({0.1f, 0.2f, 0.3f, 0.4f});
-    ASSERT_LT(index, 256u);
+    // In the new layout essenceIdx IS the material identity, so the palette
+    // entry must sit at the same index as the material id.  STONE == 1, so
+    // we need a dummy at index 0 and the real entry at index 1.
+    palette.addEntryRaw({0.0f, 0.0f, 0.0f, 0.0f});                       // index 0 (dummy)
+    const auto stoneIdx = palette.addEntryRaw({0.1f, 0.2f, 0.3f, 0.4f}); // index 1
+    ASSERT_EQ(stoneIdx, static_cast<uint8_t>(material_ids::STONE));
 
-    VoxelCell cell;
-    cell.materialId = material_ids::STONE;
-    cell.essenceIdx = static_cast<uint8_t>(index);
+    VoxelCell cell = makeCell(static_cast<uint8_t>(material_ids::STONE), Phase::Solid, 200);
 
     const auto resolved = semantics.resolve(cell, palette);
 
     EXPECT_STREQ(resolved.material.displayName, "Stone");
-    EXPECT_EQ(resolved.sampledEssence.index, index);
+    EXPECT_EQ(resolved.sampledEssence.index, stoneIdx);
     EXPECT_TRUE(resolved.sampledEssence.hasPalette);
     EXPECT_TRUE(resolved.sampledEssence.inRange);
     ASSERT_TRUE(resolved.sampledEssence.value.has_value());
@@ -156,9 +159,10 @@ TEST_F(MaterialRegistryTest, ResolveVoxelSemanticsUsesChunkLocalPaletteAsOptiona
 TEST_F(MaterialRegistryTest, ResolveVoxelSemanticsDoesNotTreatEssenceIndexAsCanonicalWithoutPalette) {
     MaterialSemanticRegistry semantics(registry);
 
-    VoxelCell cell;
-    cell.materialId = material_ids::DIRT;
-    cell.essenceIdx = 17;
+    // essenceIdx == material identity in the new layout, so just use DIRT
+    // directly.  Without a palette, resolve should fall back to intrinsic
+    // essence from the MaterialDef.
+    VoxelCell cell = makeCell(static_cast<uint8_t>(material_ids::DIRT), Phase::Solid, 150);
 
     const auto resolved = semantics.resolve(cell, nullptr);
 

--- a/tests/unit/simulation/ParallelSimulationTest.cc
+++ b/tests/unit/simulation/ParallelSimulationTest.cc
@@ -1,3 +1,4 @@
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/VoxelSimulationSystem.hh"
 #include <chrono>
 #include <gtest/gtest.h>
@@ -6,11 +7,7 @@ using namespace recurse::simulation;
 
 class ParallelSimulationTest : public ::testing::Test {
   protected:
-    VoxelCell makeMaterial(MaterialId id) {
-        VoxelCell c;
-        c.materialId = id;
-        return c;
-    }
+    VoxelCell makeMaterial(MaterialId id) { return cellForMaterial(id); }
 
     void markAllSubRegions(ChunkActivityTracker& tracker, ChunkCoord pos) {
         for (int lz = 0; lz < K_CHUNK_SIZE; lz += 8)
@@ -87,7 +84,8 @@ TEST_F(ParallelSimulationTest, IdenticalResults1vsN) {
         auto seqSnap = snapshotChunk(seqSim.grid(), cx, 0, 0);
         auto parSnap = snapshotChunk(parSim.grid(), cx, 0, 0);
         for (size_t i = 0; i < seqSnap.size(); ++i) {
-            EXPECT_EQ(seqSnap[i].materialId, parSnap[i].materialId) << "Mismatch in chunk " << cx << " at index " << i;
+            EXPECT_EQ(cellMaterialId(seqSnap[i]), cellMaterialId(parSnap[i]))
+                << "Mismatch in chunk " << cx << " at index " << i;
         }
     }
 }
@@ -193,7 +191,7 @@ TEST_F(ParallelSimulationTest, GravityTestsStillPass) {
         sim.tick();
     }
 
-    EXPECT_EQ(sim.grid().readCell(16, 1, 16).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(sim.grid().readCell(16, 1, 16)), material_ids::SAND);
 }
 
 // 6. Liquid tests still pass through the parallel dispatch path
@@ -228,7 +226,7 @@ TEST_F(ParallelSimulationTest, LiquidTestsStillPass) {
     int bottomWater = 0;
     for (int x = 11; x <= 13; ++x)
         for (int z = 11; z <= 13; ++z)
-            if (sim.grid().readCell(x, 1, z).materialId == material_ids::WATER)
+            if (cellMaterialId(sim.grid().readCell(x, 1, z)) == material_ids::WATER)
                 ++bottomWater;
     EXPECT_EQ(bottomWater, 9);
 }
@@ -264,9 +262,9 @@ TEST_F(ParallelSimulationTest, BoundaryWriteQueueCrossChunkSand) {
     }
 
     // Sand should have crossed the chunk boundary and landed at y=-1
-    EXPECT_EQ(sim.grid().readCell(16, -1, 16).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(sim.grid().readCell(16, -1, 16)), material_ids::SAND);
     // Source position should be air
-    EXPECT_EQ(sim.grid().readCell(16, 0, 16).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(sim.grid().readCell(16, 0, 16)), material_ids::AIR);
 }
 
 // 7. disableForTesting() runs inline, deterministic

--- a/tests/unit/simulation/SimulationGridTest.cc
+++ b/tests/unit/simulation/SimulationGridTest.cc
@@ -1,4 +1,5 @@
 #include "recurse/simulation/SimulationGrid.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 #include <gtest/gtest.h>
 
@@ -12,33 +13,33 @@ class SimulationGridTest : public ::testing::Test {
 // 1. Write Sand to epoch N+1 write buffer, read epoch N returns Air
 TEST_F(SimulationGridTest, ReadWriteIsolation) {
     VoxelCell sand;
-    sand.materialId = material_ids::SAND;
+    sand = cellForMaterial(material_ids::SAND);
 
     grid.fillChunk(0, 0, 0, VoxelCell{});
     grid.writeCell(0, 0, 0, sand);
 
     // Read buffer still has the old value (Air default)
     VoxelCell read = grid.readCell(0, 0, 0);
-    EXPECT_EQ(read.materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(read), material_ids::AIR);
 }
 
 // 2. Write Sand, advanceEpoch, read returns Sand
 TEST_F(SimulationGridTest, AdvanceEpochSwapsBuffers) {
     VoxelCell sand;
-    sand.materialId = material_ids::SAND;
+    sand = cellForMaterial(material_ids::SAND);
 
     grid.fillChunk(0, 0, 0, VoxelCell{});
     grid.writeCell(0, 0, 0, sand);
     grid.advanceEpoch();
 
     VoxelCell read = grid.readCell(0, 0, 0);
-    EXPECT_EQ(read.materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(read), material_ids::SAND);
 }
 
 // 3. fillChunk 1000 chunks -> materializedChunkCount == 0
 TEST_F(SimulationGridTest, HomogeneousSentinelNoAllocation) {
     VoxelCell stone;
-    stone.materialId = material_ids::STONE;
+    stone = cellForMaterial(material_ids::STONE);
 
     for (int i = 0; i < 1000; ++i) {
         grid.fillChunk(i, 0, 0, stone);
@@ -50,24 +51,24 @@ TEST_F(SimulationGridTest, HomogeneousSentinelNoAllocation) {
 // 4. fillChunk(Stone) -> readCell returns Stone
 TEST_F(SimulationGridTest, SentinelReadReturnsFillValue) {
     VoxelCell stone;
-    stone.materialId = material_ids::STONE;
+    stone = cellForMaterial(material_ids::STONE);
 
     grid.fillChunk(0, 0, 0, stone);
 
     VoxelCell read = grid.readCell(0, 0, 0);
-    EXPECT_EQ(read.materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(read), material_ids::STONE);
 }
 
 // 5. Write to sentinel -> isMaterialized, untouched cells keep fill
 TEST_F(SimulationGridTest, FirstWritePromotesSentinel) {
     VoxelCell stone;
-    stone.materialId = material_ids::STONE;
+    stone = cellForMaterial(material_ids::STONE);
 
     grid.fillChunk(0, 0, 0, stone);
     EXPECT_FALSE(grid.isChunkMaterialized(0, 0, 0));
 
     VoxelCell sand;
-    sand.materialId = material_ids::SAND;
+    sand = cellForMaterial(material_ids::SAND);
     grid.writeCell(0, 0, 0, sand);
 
     EXPECT_TRUE(grid.isChunkMaterialized(0, 0, 0));
@@ -76,7 +77,7 @@ TEST_F(SimulationGridTest, FirstWritePromotesSentinel) {
     // Cell at (1,0,0) was not written to
     grid.advanceEpoch();
     VoxelCell untouched = grid.readCell(1, 0, 0);
-    EXPECT_EQ(untouched.materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(untouched), material_ids::STONE);
 }
 
 // 6. static_assert Buffer size == 131072 bytes
@@ -89,17 +90,17 @@ TEST_F(SimulationGridTest, MaterializedChunkMemory) {
 // 7. Write at (31,0,0) and (32,0,0), both readable
 TEST_F(SimulationGridTest, CrossChunkReads) {
     VoxelCell sand;
-    sand.materialId = material_ids::SAND;
+    sand = cellForMaterial(material_ids::SAND);
 
     VoxelCell water;
-    water.materialId = material_ids::WATER;
+    water = cellForMaterial(material_ids::WATER);
 
     grid.writeCell(31, 0, 0, sand);
     grid.writeCell(32, 0, 0, water);
     grid.advanceEpoch();
 
-    EXPECT_EQ(grid.readCell(31, 0, 0).materialId, material_ids::SAND);
-    EXPECT_EQ(grid.readCell(32, 0, 0).materialId, material_ids::WATER);
+    EXPECT_EQ(cellMaterialId(grid.readCell(31, 0, 0)), material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(32, 0, 0)), material_ids::WATER);
 
     // They should be in different chunks
     EXPECT_TRUE(grid.hasChunk(0, 0, 0));
@@ -109,12 +110,12 @@ TEST_F(SimulationGridTest, CrossChunkReads) {
 // 8. Write (-1,-1,-1) creates chunk (-1,-1,-1) correctly
 TEST_F(SimulationGridTest, NegativeCoordinates) {
     VoxelCell dirt;
-    dirt.materialId = material_ids::DIRT;
+    dirt = cellForMaterial(material_ids::DIRT);
 
     grid.writeCell(-1, -1, -1, dirt);
     grid.advanceEpoch();
 
-    EXPECT_EQ(grid.readCell(-1, -1, -1).materialId, material_ids::DIRT);
+    EXPECT_EQ(cellMaterialId(grid.readCell(-1, -1, -1)), material_ids::DIRT);
     EXPECT_TRUE(grid.hasChunk(-1, -1, -1));
 }
 
@@ -123,13 +124,12 @@ TEST_F(SimulationGridTest, MultipleEpochCycles) {
     grid.fillChunk(0, 0, 0, VoxelCell{});
 
     for (uint64_t e = 0; e < 10; ++e) {
-        VoxelCell cell;
-        cell.materialId = static_cast<MaterialId>(e % material_ids::COUNT);
+        VoxelCell cell = cellForMaterial(static_cast<MaterialId>(e % material_ids::COUNT));
         grid.writeCell(0, 0, 0, cell);
         grid.advanceEpoch();
 
         VoxelCell read = grid.readCell(0, 0, 0);
-        EXPECT_EQ(read.materialId, static_cast<MaterialId>(e % material_ids::COUNT)) << "Failed at epoch " << e;
+        EXPECT_EQ(cellMaterialId(read), static_cast<MaterialId>(e % material_ids::COUNT)) << "Failed at epoch " << e;
     }
     EXPECT_EQ(grid.currentEpoch(), 10u);
 }
@@ -137,7 +137,7 @@ TEST_F(SimulationGridTest, MultipleEpochCycles) {
 // 10. readBuffer/writeBuffer match readCell/writeCell
 TEST_F(SimulationGridTest, RawBufferMatchesReadWrite) {
     VoxelCell stone;
-    stone.materialId = material_ids::STONE;
+    stone = cellForMaterial(material_ids::STONE);
 
     grid.fillChunk(0, 0, 0, VoxelCell{});
     grid.materializeChunk(0, 0, 0);
@@ -152,38 +152,38 @@ TEST_F(SimulationGridTest, RawBufferMatchesReadWrite) {
     // Read via readBuffer
     const auto* rb = grid.readBuffer(0, 0, 0);
     ASSERT_NE(rb, nullptr);
-    EXPECT_EQ((*rb)[0].materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId((*rb)[0]), material_ids::STONE);
 
     // Should match readCell
-    EXPECT_EQ(grid.readCell(0, 0, 0).materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 0, 0)), material_ids::STONE);
 }
 
 // 11. writeCellImmediate visible in read buffer without advanceEpoch
 TEST_F(SimulationGridTest, WriteCellImmediateVisibleWithoutEpochAdvance) {
     VoxelCell sand;
-    sand.materialId = material_ids::SAND;
+    sand = cellForMaterial(material_ids::SAND);
 
     grid.fillChunk(0, 0, 0, VoxelCell{});
     grid.writeCellImmediate(0, 0, 0, sand);
 
     // Read buffer sees the value immediately -- no advanceEpoch needed
-    EXPECT_EQ(grid.readCell(0, 0, 0).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 0, 0)), material_ids::SAND);
 
     // Write buffer also has the value
-    EXPECT_EQ(grid.readFromWriteBuffer(0, 0, 0).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readFromWriteBuffer(0, 0, 0)), material_ids::SAND);
 }
 
 // 12. writeCellImmediate value preserved across advanceEpoch
 TEST_F(SimulationGridTest, WriteCellImmediatePreservedAcrossEpoch) {
     VoxelCell sand;
-    sand.materialId = material_ids::SAND;
+    sand = cellForMaterial(material_ids::SAND);
 
     grid.fillChunk(0, 0, 0, VoxelCell{});
     grid.writeCellImmediate(0, 0, 0, sand);
     grid.advanceEpoch();
 
     // Value survives the epoch swap
-    EXPECT_EQ(grid.readCell(0, 0, 0).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 0, 0)), material_ids::SAND);
 }
 
 // 13. advanceEpoch preserves untouched cells across K_COUNT * 3 cycles.
@@ -194,7 +194,7 @@ TEST_F(SimulationGridTest, UntouchedCellsSurviveManyCycles) {
     grid.materializeChunk(0, 0, 0);
 
     VoxelCell stone;
-    stone.materialId = material_ids::STONE;
+    stone = cellForMaterial(material_ids::STONE);
     grid.writeCell(0, 0, 0, stone);
     grid.advanceEpoch();
 
@@ -204,11 +204,11 @@ TEST_F(SimulationGridTest, UntouchedCellsSurviveManyCycles) {
     for (int i = 0; i < cycles; ++i) {
         // Write to a DIFFERENT cell each epoch to exercise the buffers
         VoxelCell sand;
-        sand.materialId = material_ids::SAND;
+        sand = cellForMaterial(material_ids::SAND);
         grid.writeCell(1, 0, 0, sand);
         grid.advanceEpoch();
 
-        EXPECT_EQ(grid.readCell(0, 0, 0).materialId, material_ids::STONE) << "Untouched cell lost at cycle " << i;
+        EXPECT_EQ(cellMaterialId(grid.readCell(0, 0, 0)), material_ids::STONE) << "Untouched cell lost at cycle " << i;
     }
 }
 
@@ -236,20 +236,20 @@ TEST_F(SimulationGridTest, VoxelCellEssenceIdxDefaultZero) {
 
 TEST_F(SimulationGridTest, VoxelCellEssenceIdxPreservedInCopy) {
     VoxelCell cell{};
-    cell.materialId = material_ids::STONE;
+    cell = cellForMaterial(material_ids::STONE);
     cell.essenceIdx = 42;
-    cell.flags = voxel_flags::NONE;
+    cell.setFlags(voxel_flags::NONE);
 
     VoxelCell copy = cell;
     EXPECT_EQ(copy.essenceIdx, 42u);
-    EXPECT_EQ(copy.materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(copy), static_cast<MaterialId>(42));
 }
 
 // --- Group A: Essence round-trip through epoch ---
 
 TEST_F(SimulationGridTest, EssenceIdxPreservedAcrossEpoch) {
     VoxelCell cell{};
-    cell.materialId = material_ids::STONE;
+    cell = cellForMaterial(material_ids::STONE);
     cell.essenceIdx = 42;
 
     grid.fillChunk(0, 0, 0, VoxelCell{});
@@ -262,7 +262,7 @@ TEST_F(SimulationGridTest, EssenceIdxPreservedAcrossEpoch) {
 
 TEST_F(SimulationGridTest, EssenceIdxPreservedMultipleEpochs) {
     VoxelCell cell{};
-    cell.materialId = material_ids::STONE;
+    cell = cellForMaterial(material_ids::STONE);
     cell.essenceIdx = 200;
 
     grid.fillChunk(0, 0, 0, VoxelCell{});
@@ -271,7 +271,7 @@ TEST_F(SimulationGridTest, EssenceIdxPreservedMultipleEpochs) {
 
     for (int i = 0; i < 10; ++i) {
         VoxelCell other{};
-        other.materialId = material_ids::SAND;
+        other = cellForMaterial(material_ids::SAND);
         other.essenceIdx = static_cast<uint8_t>(i);
         grid.writeCell(1, 0, 0, other);
         grid.advanceEpoch();
@@ -290,7 +290,7 @@ TEST_F(SimulationGridTest, EssenceIdxZeroIsDefault) {
 
 TEST_F(SimulationGridTest, EssenceIdxSurvivesWriteCellImmediate) {
     VoxelCell cell{};
-    cell.materialId = material_ids::STONE;
+    cell = cellForMaterial(material_ids::STONE);
     cell.essenceIdx = 100;
 
     grid.fillChunk(0, 0, 0, VoxelCell{});

--- a/tests/unit/simulation/VoxelSimulationSystemTest.cc
+++ b/tests/unit/simulation/VoxelSimulationSystemTest.cc
@@ -1,6 +1,7 @@
 #include "recurse/simulation/VoxelSimulationSystem.hh"
 #include "fabric/world/ChunkedGrid.hh"
 #include "recurse/character/VoxelInteraction.hh"
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/ChunkActivityTracker.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
@@ -36,11 +37,7 @@ class VoxelSimulationSystemTest : public ::testing::Test {
                     sim.activityTracker().markSubRegionActive(pos, lx, ly, lz);
     }
 
-    VoxelCell makeMaterial(MaterialId id) {
-        VoxelCell c;
-        c.materialId = id;
-        return c;
-    }
+    VoxelCell makeMaterial(MaterialId id) { return cellForMaterial(id); }
 
     void placeCellAndAdvance(int wx, int wy, int wz, VoxelCell cell) {
         sim.grid().writeCell(wx, wy, wz, cell);
@@ -72,7 +69,7 @@ class VoxelSimulationSystemTest : public ::testing::Test {
         for (int z = 0; z < K_CHUNK_SIZE; ++z)
             for (int y = 0; y < K_CHUNK_SIZE; ++y)
                 for (int x = 0; x < K_CHUNK_SIZE; ++x)
-                    if (sim.grid().readCell(x, y, z).materialId == id)
+                    if (cellMaterialId(sim.grid().readCell(x, y, z)) == id)
                         ++count;
         return count;
     }
@@ -111,7 +108,7 @@ TEST_F(VoxelSimulationSystemTest, SandFallsOverTicks) {
     }
 
     // Sand should be at y=1 (on top of stone floor)
-    EXPECT_EQ(sim.grid().readCell(16, 1, 16).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(sim.grid().readCell(16, 1, 16)), material_ids::SAND);
 }
 
 // 3. Water fills a stone box cavity over ticks
@@ -134,7 +131,7 @@ TEST_F(VoxelSimulationSystemTest, WaterFillsCavity) {
     int bottomWater = 0;
     for (int x = 11; x <= 13; ++x)
         for (int z = 11; z <= 13; ++z)
-            if (sim.grid().readCell(x, 1, z).materialId == material_ids::WATER)
+            if (cellMaterialId(sim.grid().readCell(x, 1, z)) == material_ids::WATER)
                 ++bottomWater;
     EXPECT_EQ(bottomWater, 9);
 }
@@ -203,7 +200,7 @@ TEST_F(VoxelSimulationSystemTest, GridAccessible) {
     auto& g = sim.grid();
     g.writeCell(0, 0, 0, makeMaterial(material_ids::SAND));
     g.advanceEpoch();
-    EXPECT_EQ(g.readCell(0, 0, 0).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(g.readCell(0, 0, 0)), material_ids::SAND);
 }
 
 // 8. Total sand count is conserved over 50 ticks
@@ -275,11 +272,11 @@ TEST(RecurseVoxelSimSystemTest, LiquidFlowsHorizontally) {
 
     for (int x = 0; x < K_CHUNK_SIZE; ++x)
         for (int z = 0; z < K_CHUNK_SIZE; ++z)
-            grid.writeCell(x, 0, z, VoxelCell{material_ids::STONE});
+            grid.writeCell(x, 0, z, cellForMaterial(material_ids::STONE));
     grid.advanceEpoch();
 
     for (int y = 1; y <= 4; ++y)
-        grid.writeCell(16, y, 16, VoxelCell{material_ids::WATER});
+        grid.writeCell(16, y, 16, cellForMaterial(material_ids::WATER));
     grid.advanceEpoch();
 
     auto countWater = [&]() {
@@ -288,8 +285,8 @@ TEST(RecurseVoxelSimSystemTest, LiquidFlowsHorizontally) {
             for (int lz = 0; lz < K_CHUNK_SIZE; ++lz)
                 for (int ly = 0; ly < K_CHUNK_SIZE; ++ly)
                     for (int lx = 0; lx < K_CHUNK_SIZE; ++lx)
-                        if (grid.readCell(cx * K_CHUNK_SIZE + lx, cy * K_CHUNK_SIZE + ly, cz * K_CHUNK_SIZE + lz)
-                                .materialId == material_ids::WATER)
+                        if (cellMaterialId(grid.readCell(cx * K_CHUNK_SIZE + lx, cy * K_CHUNK_SIZE + ly,
+                                                         cz * K_CHUNK_SIZE + lz)) == material_ids::WATER)
                             ++count;
         return count;
     };
@@ -310,16 +307,16 @@ TEST(RecurseVoxelSimSystemTest, WakeOnNeighborActivity) {
     sim.scheduler().disableForTesting();
     auto& grid = sim.grid();
 
-    grid.fillChunk(0, 0, 0, VoxelCell{material_ids::STONE});
+    grid.fillChunk(0, 0, 0, cellForMaterial(material_ids::STONE));
     grid.advanceEpoch();
     sim.activityTracker().setState(ChunkCoord{0, 0, 0}, ChunkState::Sleeping);
 
     for (int x = K_CHUNK_SIZE; x < K_CHUNK_SIZE * 2; ++x)
         for (int z = 0; z < K_CHUNK_SIZE; ++z)
-            grid.writeCell(x, 0, z, VoxelCell{material_ids::STONE});
+            grid.writeCell(x, 0, z, cellForMaterial(material_ids::STONE));
     grid.advanceEpoch();
 
-    grid.writeCell(K_CHUNK_SIZE, 5, 16, VoxelCell{material_ids::SAND});
+    grid.writeCell(K_CHUNK_SIZE, 5, 16, cellForMaterial(material_ids::SAND));
     grid.advanceEpoch();
     sim.activityTracker().setState(ChunkCoord{1, 0, 0}, ChunkState::Active);
 
@@ -336,7 +333,7 @@ TEST(RecurseVoxelSimSystemTest, GhostCellCopyCorrectness) {
     sim.scheduler().disableForTesting();
     auto& grid = sim.grid();
 
-    grid.writeCell(31, 0, 0, VoxelCell{material_ids::STONE});
+    grid.writeCell(31, 0, 0, cellForMaterial(material_ids::STONE));
     grid.advanceEpoch();
 
     grid.materializeChunk(0, 0, 0);
@@ -348,7 +345,7 @@ TEST(RecurseVoxelSimSystemTest, GhostCellCopyCorrectness) {
     sim.tick();
 
     auto cell = grid.readCell(31, 0, 0);
-    EXPECT_EQ(cell.materialId, material_ids::STONE) << "Boundary voxel should be preserved after ghost sync";
+    EXPECT_EQ(cellMaterialId(cell), material_ids::STONE) << "Boundary voxel should be preserved after ghost sync";
 }
 
 TEST(RecurseVoxelSimSystemTest, ApplyExternalEditIntoSleepingChunkWritesAndSimulatesWithoutCallerRepair) {
@@ -385,12 +382,13 @@ TEST(RecurseVoxelSimSystemTest, ApplyExternalEditIntoSleepingChunkWritesAndSimul
     grid.materializeChunk(0, 0, 0);
     for (int x = 0; x < K_CHUNK_SIZE; ++x)
         for (int z = 0; z < K_CHUNK_SIZE; ++z)
-            grid.writeCellImmediate(x, 0, z, VoxelCell{material_ids::STONE});
+            grid.writeCellImmediate(x, 0, z, cellForMaterial(material_ids::STONE));
 
     sim->activityTracker().setState(ChunkCoord{0, 0, 0}, ChunkState::Sleeping);
 
     VoxelCell air{};
-    VoxelCell sand{material_ids::SAND, 0, voxel_flags::UPDATED};
+    VoxelCell sand = cellForMaterial(material_ids::SAND);
+    sand.setFlags(voxel_flags::UPDATED);
     uint32_t oldCell = 0;
     uint32_t newCell = 0;
     std::memcpy(&oldCell, &air, sizeof(uint32_t));
@@ -412,7 +410,7 @@ TEST(RecurseVoxelSimSystemTest, ApplyExternalEditIntoSleepingChunkWritesAndSimul
     sim->applyExternalEdit(edit);
 
     EXPECT_EQ(sim->activityTracker().getState(ChunkCoord{0, 0, 0}), ChunkState::Active);
-    EXPECT_EQ(grid.readCell(16, 10, 16).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 10, 16)), material_ids::SAND);
     ASSERT_EQ(eventCount, 1);
     ASSERT_EQ(details.size(), 1u);
     EXPECT_EQ(details[0].vx, 16);
@@ -435,8 +433,8 @@ TEST(RecurseVoxelSimSystemTest, ApplyExternalEditIntoSleepingChunkWritesAndSimul
 
     sysReg.runFixedUpdate(ctx, 1.0f / 60.0f);
 
-    EXPECT_EQ(grid.readCell(16, 9, 16).materialId, material_ids::SAND);
-    EXPECT_EQ(grid.readCell(16, 10, 16).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 9, 16)), material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 10, 16)), material_ids::AIR);
 
     sysReg.shutdownAll();
 }

--- a/tests/unit/world/GeneratorTest.cc
+++ b/tests/unit/world/GeneratorTest.cc
@@ -1,3 +1,4 @@
+#include "recurse/simulation/CellAccessors.hh"
 #include "recurse/simulation/SimulationGrid.hh"
 #include "recurse/simulation/VoxelMaterial.hh"
 #include "recurse/world/FlatGenerator.hh"
@@ -21,9 +22,9 @@ TEST_F(GeneratorTest, FlatBelowSurface) {
     grid.advanceEpoch();
 
     // worldY=0 should be Stone
-    EXPECT_EQ(grid.readCell(0, 0, 0).materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 0, 0)), material_ids::STONE);
     // worldY=15 should be Stone
-    EXPECT_EQ(grid.readCell(0, 15, 0).materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 15, 0)), material_ids::STONE);
 }
 
 // 2. FlatAboveSurface -- Above = Air
@@ -33,9 +34,9 @@ TEST_F(GeneratorTest, FlatAboveSurface) {
     grid.advanceEpoch();
 
     // worldY=17 should be Air
-    EXPECT_EQ(grid.readCell(0, 17, 0).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 17, 0)), material_ids::AIR);
     // worldY=31 should be Air
-    EXPECT_EQ(grid.readCell(0, 31, 0).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 31, 0)), material_ids::AIR);
 }
 
 // 3. FlatSurfaceLayer -- Surface = Dirt
@@ -44,21 +45,21 @@ TEST_F(GeneratorTest, FlatSurfaceLayer) {
     gen.generate(grid, 0, 0, 0);
     grid.advanceEpoch();
 
-    EXPECT_EQ(grid.readCell(0, 16, 0).materialId, material_ids::DIRT);
-    EXPECT_EQ(grid.readCell(15, 16, 15).materialId, material_ids::DIRT);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 16, 0)), material_ids::DIRT);
+    EXPECT_EQ(cellMaterialId(grid.readCell(15, 16, 15)), material_ids::DIRT);
 }
 
 // 4. SingleMaterialFills -- All cells = specified material
 TEST_F(GeneratorTest, SingleMaterialFills) {
     VoxelCell water;
-    water.materialId = material_ids::WATER;
+    water = cellForMaterial(material_ids::WATER);
     SingleMaterialGenerator gen(water);
     gen.generate(grid, 0, 0, 0);
 
     // SingleMaterial uses fillChunk (sentinel), so reads should return Water
-    EXPECT_EQ(grid.readCell(0, 0, 0).materialId, material_ids::WATER);
-    EXPECT_EQ(grid.readCell(16, 16, 16).materialId, material_ids::WATER);
-    EXPECT_EQ(grid.readCell(31, 31, 31).materialId, material_ids::WATER);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 0, 0)), material_ids::WATER);
+    EXPECT_EQ(cellMaterialId(grid.readCell(16, 16, 16)), material_ids::WATER);
+    EXPECT_EQ(cellMaterialId(grid.readCell(31, 31, 31)), material_ids::WATER);
 
     // Should not be materialized (sentinel optimization)
     EXPECT_FALSE(grid.isChunkMaterialized(0, 0, 0));
@@ -67,35 +68,35 @@ TEST_F(GeneratorTest, SingleMaterialFills) {
 // 5. LayeredBoundaries -- Exact Y boundaries
 TEST_F(GeneratorTest, LayeredBoundaries) {
     VoxelCell stone;
-    stone.materialId = material_ids::STONE;
+    stone = cellForMaterial(material_ids::STONE);
     VoxelCell dirt;
-    dirt.materialId = material_ids::DIRT;
+    dirt = cellForMaterial(material_ids::DIRT);
 
     LayeredGenerator gen({{stone, 0, 9}, {dirt, 10, 19}});
     gen.generate(grid, 0, 0, 0);
     grid.advanceEpoch();
 
-    EXPECT_EQ(grid.readCell(0, 9, 0).materialId, material_ids::STONE);
-    EXPECT_EQ(grid.readCell(0, 10, 0).materialId, material_ids::DIRT);
-    EXPECT_EQ(grid.readCell(0, 19, 0).materialId, material_ids::DIRT);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 9, 0)), material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 10, 0)), material_ids::DIRT);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 19, 0)), material_ids::DIRT);
     // worldY=20 above both layers -> Air (default fill)
-    EXPECT_EQ(grid.readCell(0, 20, 0).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 20, 0)), material_ids::AIR);
 }
 
 // 6. LayeredMultiple -- 3+ layers correct
 TEST_F(GeneratorTest, LayeredMultiple) {
     VoxelCell stone, dirt, sand;
-    stone.materialId = material_ids::STONE;
-    dirt.materialId = material_ids::DIRT;
-    sand.materialId = material_ids::SAND;
+    stone = cellForMaterial(material_ids::STONE);
+    dirt = cellForMaterial(material_ids::DIRT);
+    sand = cellForMaterial(material_ids::SAND);
 
     LayeredGenerator gen({{stone, 0, 4}, {dirt, 5, 9}, {sand, 10, 14}});
     gen.generate(grid, 0, 0, 0);
     grid.advanceEpoch();
 
-    EXPECT_EQ(grid.readCell(0, 2, 0).materialId, material_ids::STONE);
-    EXPECT_EQ(grid.readCell(0, 7, 0).materialId, material_ids::DIRT);
-    EXPECT_EQ(grid.readCell(0, 12, 0).materialId, material_ids::SAND);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 2, 0)), material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 7, 0)), material_ids::DIRT);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 12, 0)), material_ids::SAND);
 }
 
 // 7. NoBgfxDependency -- Compiles without bgfx (verified by this test compiling)
@@ -116,8 +117,8 @@ TEST_F(GeneratorTest, NegativeYChunks) {
     gen.generate(grid, 0, -1, 0);
     grid.advanceEpoch();
 
-    EXPECT_EQ(grid.readCell(0, -1, 0).materialId, material_ids::STONE);
-    EXPECT_EQ(grid.readCell(0, -32, 0).materialId, material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, -1, 0)), material_ids::STONE);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, -32, 0)), material_ids::STONE);
 }
 
 // 9. AboveSurfaceAllAir -- chunk above surface = all air (sentinel)
@@ -130,8 +131,8 @@ TEST_F(GeneratorTest, AboveSurfaceAllAir) {
     EXPECT_FALSE(grid.isChunkMaterialized(0, 1, 0));
 
     // All reads should return Air
-    EXPECT_EQ(grid.readCell(0, 32, 0).materialId, material_ids::AIR);
-    EXPECT_EQ(grid.readCell(0, 63, 0).materialId, material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 32, 0)), material_ids::AIR);
+    EXPECT_EQ(cellMaterialId(grid.readCell(0, 63, 0)), material_ids::AIR);
 }
 
 // 10. GeneratorName -- Verify name() returns correct string

--- a/tests/unit/world/MinecraftNoiseGeneratorTest.cc
+++ b/tests/unit/world/MinecraftNoiseGeneratorTest.cc
@@ -20,7 +20,7 @@ class MinecraftNoiseGenTest : public ::testing::Test {
     // Find highest solid Y in a column (wx, wz) within a chunk range
     int surfaceY(SimulationGrid& g, int wx, int wz, int minY, int maxY) {
         for (int y = maxY; y >= minY; --y) {
-            auto mat = g.readCell(wx, y, wz).materialId;
+            auto mat = cellMaterialId(g.readCell(wx, y, wz));
             if (mat != material_ids::AIR && mat != material_ids::WATER) {
                 return y;
             }
@@ -110,7 +110,7 @@ TEST_F(MinecraftNoiseGenTest, SeaLevelProducesWater) {
                 for (int ly = 0; ly < K_CHUNK; ++ly)
                     for (int lx = 0; lx < K_CHUNK; lx += 4)
                         for (int lz = 0; lz < K_CHUNK; lz += 4)
-                            if (grid.readCell(bx + lx, by + ly, bz + lz).materialId == material_ids::WATER)
+                            if (cellMaterialId(grid.readCell(bx + lx, by + ly, bz + lz)) == material_ids::WATER)
                                 ++waterCount;
             }
         }
@@ -148,7 +148,7 @@ TEST_F(MinecraftNoiseGenTest, SurfaceMaterialVaries) {
                 for (int lz = 0; lz < K_CHUNK; lz += 4) {
                     int sy = surfaceY(grid, bx + lx, bz + lz, 0, 63);
                     if (sy >= 0) {
-                        auto mat = grid.readCell(bx + lx, sy, bz + lz).materialId;
+                        auto mat = cellMaterialId(grid.readCell(bx + lx, sy, bz + lz));
                         if (mat != material_ids::STONE) {
                             surfaceMats.insert(mat);
                         }
@@ -173,7 +173,7 @@ TEST_F(MinecraftNoiseGenTest, BulkUndergroundStone) {
 
     // All cells this deep should be Stone (density >> 3)
     for (int y = -32; y < -1; ++y) {
-        EXPECT_EQ(grid.readCell(0, y, 0).materialId, material_ids::STONE) << "Expected Stone at y=" << y;
+        EXPECT_EQ(cellMaterialId(grid.readCell(0, y, 0)), material_ids::STONE) << "Expected Stone at y=" << y;
     }
 }
 
@@ -201,7 +201,8 @@ TEST_F(MinecraftNoiseGenTest, DeterministicSameSeed) {
             for (int lx = 0; lx < K_CHUNK; ++lx) {
                 auto c1 = grid1.readCell(bx + lx, by + ly, bz + lz);
                 auto c2 = grid2.readCell(bx + lx, by + ly, bz + lz);
-                EXPECT_EQ(c1.materialId, c2.materialId) << "Mismatch at (" << lx << "," << ly << "," << lz << ")";
+                EXPECT_EQ(cellMaterialId(c1), cellMaterialId(c2))
+                    << "Mismatch at (" << lx << "," << ly << "," << lz << ")";
             }
         }
     }
@@ -234,7 +235,7 @@ TEST_F(MinecraftNoiseGenTest, DifferentSeeds) {
             for (int lx = 0; lx < K_CHUNK; ++lx) {
                 auto c1 = grid1.readCell(bx + lx, by + ly, bz + lz);
                 auto c2 = grid2.readCell(bx + lx, by + ly, bz + lz);
-                if (c1.materialId != c2.materialId) {
+                if (cellMaterialId(c1) != cellMaterialId(c2)) {
                     ++differences;
                 }
             }
@@ -311,7 +312,7 @@ TEST_F(MinecraftNoiseGenTest, ShorelineMaterialsAreContextual) {
             if (sy < 0 || std::abs(sy - static_cast<int>(config.seaLevel)) > 4)
                 continue;
 
-            const auto mat = grid.readCell(wx, sy, wz).materialId;
+            const auto mat = cellMaterialId(grid.readCell(wx, sy, wz));
             if (mat != material_ids::STONE) {
                 shorelineMaterials.insert(mat);
             }
@@ -417,7 +418,7 @@ TEST_F(MinecraftNoiseGenTest, SampleMaterialMatchesGenerateToBufferAtChunkWorldC
                     int wy = baseY + ly;
                     int wz = baseZ + lz;
                     int idx = lx + ly * K_CHUNK + lz * K_CHUNK * K_CHUNK;
-                    ASSERT_EQ(gen.sampleMaterial(wx, wy, wz), buffer[idx].materialId)
+                    ASSERT_EQ(gen.sampleMaterial(wx, wy, wz), cellMaterialId(buffer[idx]))
                         << "world=(" << wx << "," << wy << "," << wz << ")";
                 }
             }


### PR DESCRIPTION
## Summary

Wave 4 of the MatterState migration: the live cell layout swap.

- `VoxelCell` struct changed from `{MaterialId(u16), essenceIdx(u8), flags(u8)}` to `{essenceIdx(u8), displacementRank(u8), phaseAndFlags(u8), spare(u8)}`
- All production code and 48 test files migrated to factory functions (`makeCell`, `cellForMaterial`, `emptyCell`) and read accessors (`cellMaterialId`, `cellPhase`, `canDisplace`)
- `EssenceAssigner` writes palette indices to `cell.spare` instead of `cell.essenceIdx`
- FchkCodec bumped to v4 with v2-to-v4 migration on load
- `CellFactoryTest` added for factory function coverage
- `ProjectionRuleTable` guard replaced with `std::min` loop bound (cppcheck clean)

## Key design decisions

- **Strangler-fig payoff**: Waves 1-2 wrapped all direct field access behind narrow accessors. This wave's struct swap only changed accessor bodies, not 100+ consumer call sites. B4/B7/B8 required zero production code changes.
- **essenceIdx == materialId invariant**: During migration, `cellMaterialId(cell)` returns `static_cast<MaterialId>(cell.essenceIdx)`. This 1:1 mapping holds until essence-first terrain generation replaces it.
- **FchkCodec v4**: Old saves (v1/v2) auto-migrate on load by deriving phase and displacementRank from the old materialId byte. Runtime flags masked at every decode path.

## Verification

- `mise run build`: zero errors
- `mise run test`: 2281 passed, 0 failed, 3 skipped (Vulkan runtime)
- `mise run cppcheck`: clean (zero warnings)
- `static_assert(sizeof(VoxelCell) == 4)` holds

## Test plan

- [x] Build succeeds with zero errors
- [x] All 2281 unit tests pass
- [x] cppcheck clean
- [x] FchkCodec v2-to-v4 migration covered by round-trip tests
- [x] CellFactoryTest covers makeCell, cellForMaterial, emptyCell, makeCellFromMaterial
- [x] Manual smoke: Recurse binary launches and renders without regression